### PR TITLE
Create a `cabal.project` file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: */*.cabal
+
+package *
+  flags: -Wall -Wextra -Wunused-packages
+  library-for-ghci: true
+  ghc-options: -fno-ghci-sandbox


### PR DESCRIPTION
Some basic defaults, plus `-fno-ghci-sandbox` which _hopefully_ allows me to create SDL windows within GHCi.