### PR TITLE
Test `Roughly` properly

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -31,5 +31,7 @@ test-suite shaders-test
   other-modules:
     MyLib
 
+    Helper.Roughly
+    Helper.RoughlySpec
     Helper.Renderer
     Helper.RendererSpec

--- a/shaders/tests/Helper/Roughly.hs
+++ b/shaders/tests/Helper/Roughly.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module Helper.Roughly where
+
+import Control.Monad.Zip (MonadZip (mzipWith))
+import Data.Function (on)
+import Data.Kind (Type)
+import Hedgehog ((===), MonadTest)
+
+-- | A "rough equality" check on two vectors. We're doing a lot of floating
+-- point arithmetic, so we're going to end up with some sort of error.
+isRoughly :: (MonadTest m, MonadZip f, Foldable f, Fractional x, Ord x, Show (f x)) => f x -> f x -> m ()
+isRoughly = (===) `on` Roughly
+
+-- | A type that implements "rough" equality, where "rough" precisely means
+-- that two values are equal if no absolute component-wise difference is more
+-- than a 256th of the total.
+type Roughly :: (Type -> Type) -> Type -> Type
+newtype Roughly f x = Roughly (f x)
+  deriving stock (Foldable, Traversable)
+  deriving newtype (Show, Functor, Applicative)
+
+instance (MonadZip f, Foldable f, Fractional x, Ord x) => Eq (Roughly f x) where
+  Roughly xs == Roughly ys = and (mzipWith isCloseEnough xs ys)
+    where
+      isCloseEnough :: x -> x -> Bool
+      isCloseEnough x y = abs (x - y) <= maximum [ 1, abs x, abs y ] / 256

--- a/shaders/tests/Helper/RoughlySpec.hs
+++ b/shaders/tests/Helper/RoughlySpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Helper.RoughlySpec where
+
+import Hedgehog (Gen, forAll)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helper.Roughly (isRoughly)
+import Linear (V3)
+import Test.Hspec (Spec, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+gen_vector :: Gen (V3 Float)
+gen_vector = sequence $ pure do
+  Gen.float (Range.linearFrac 0 1000)
+
+spec :: Spec
+spec = do
+  it "commutative float addition" $ hedgehog do
+    x <- forAll gen_vector
+    y <- forAll gen_vector
+
+    (x + y) `isRoughly` (y + x)
+
+  it "associative float addition" $ hedgehog do
+    x <- forAll gen_vector
+    y <- forAll gen_vector
+    z <- forAll gen_vector
+
+    (x + (y + z)) `isRoughly` ((x + y) + z)
+
+  it "commutative float multiplication" $ hedgehog do
+    x <- forAll gen_vector
+    y <- forAll gen_vector
+
+    (x * y) `isRoughly` (y * x)
+
+  it "associative float multiplication" $ hedgehog do
+    x <- forAll gen_vector
+    y <- forAll gen_vector
+    z <- forAll gen_vector
+
+    (x * (y * z)) `isRoughly` ((x * y) * z)


### PR DESCRIPTION
Found a couple awkward bugs while testing (mostly around needing to expand the error margin), but now it's property tested and everything.