### PR TITLE
Remove the `-fno-ghci-sandbox` option

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,3 @@ packages: */*.cabal
 package *
   flags: -Wall -Wextra -Wunused-packages
   library-for-ghci: true
-  ghc-options: -fno-ghci-sandbox


### PR DESCRIPTION
This... didn't work 🤔 I still can't run the renderer tests in GHCi.