### PR TITLE
Allow for lifting numeric constants into GLSL

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -5,6 +5,9 @@ version: 0.1.0.0
 library
   exposed-modules:
     Shader.Expression
+  other-modules:
+    Shader.Expression.Constants
+    Shader.Expression.Core
   build-depends:
     , base
     , language-glsl
@@ -35,6 +38,10 @@ test-suite shaders-test
     hspec-discover:hspec-discover
   other-modules:
     Shader.Expression
+    Shader.Expression.SpecHook
+    Shader.Expression.Constants
+    Shader.Expression.ConstantsSpec
+    Shader.Expression.Core
 
     Helper.Roughly
     Helper.RoughlySpec

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -1,31 +1,11 @@
-{-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE ViewPatterns #-}
-
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
-module Shader.Expression where
+module Shader.Expression
+  ( Expr (toGLSL),
+    lift,
+    vec4,
+  )
+where
 
-import Data.Kind (Constraint, Type)
-import Graphics.Rendering.OpenGL (GLfloat)
-import Language.GLSL.Syntax qualified as Syntax
-import Linear (V4)
-
--- | An expression is a GLSL value that has a type. In practice, because all
--- computation will be performed on the GPU once we've compiled the shader, the
--- type here is entirely phantom - it's just there to make the operations
--- well typed.
-type Expr :: Type -> Type
-newtype Expr x = Expr {toGLSL :: Syntax.Expr}
-
--- | Lift a constant value into a GLSL computation.
-type Lift :: Type -> Constraint
-class Lift x where lift :: x -> Expr x
-
-instance Lift GLfloat where lift = Expr . Syntax.FloatConstant
-
--- | Create a @vec4@ from four 'GLfloat' 'Expr' components. This will probably
--- be replaced with a class in the near future to reflect the different ways in
--- which GLSL overloads this function.
-vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
-vec4 (toGLSL -> x) (toGLSL -> y) (toGLSL -> z) (toGLSL -> w) = Expr do
-  Syntax.FunctionCall (Syntax.FuncId "vec4") $ Syntax.Params [x, y, z, w]
+import Shader.Expression.Constants (lift)
+import Shader.Expression.Core (Expr (toGLSL), vec4)

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -1,0 +1,41 @@
+-- |
+-- Utilities for lifting constants into GLSL.
+module Shader.Expression.Constants
+  ( Lift (lift),
+    fromInteger,
+    fromRational,
+  )
+where
+
+import Data.Kind (Constraint, Type)
+import Graphics.Rendering.OpenGL (GLdouble, GLfloat, GLint, GLuint)
+import Language.GLSL.Syntax qualified as Syntax
+import Shader.Expression.Core (Expr (Expr))
+import Prelude hiding (fromInteger, fromRational)
+import Prelude qualified
+
+-- | Lift any expressable type into @GLSL@.
+type Lift :: Type -> Constraint
+class Lift x where
+  -- | Lift a value into @GLSL@.
+  lift :: x -> Expr x
+
+instance Lift GLdouble where
+  lift = Expr . Syntax.FloatConstant . realToFrac
+
+instance Lift GLfloat where
+  lift = Expr . Syntax.FloatConstant
+
+instance Lift GLint where
+  lift = Expr . Syntax.IntConstant Syntax.Decimal . fromIntegral
+
+instance Lift GLuint where
+  lift = Expr . Syntax.IntConstant Syntax.Decimal . fromIntegral
+
+-- | @RebindableSyntax@ function for integer literals.
+fromInteger :: (Lift x, Num x) => Integer -> Expr x
+fromInteger = lift . Prelude.fromInteger
+
+-- | @RebindableSyntax@ function for rational literals.
+fromRational :: (Lift x, Fractional x) => Rational -> Expr x
+fromRational = lift . Prelude.fromRational

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Typed syntactic sugar on top of @language-glsl@.
+module Shader.Expression.Core where
+
+import Data.Kind (Constraint, Type)
+import Graphics.Rendering.OpenGL (GLfloat)
+import Language.GLSL.Syntax qualified as Syntax
+import Linear (V4)
+
+-- | An expression is a GLSL value that has a type. In practice, because all
+-- computation will be performed on the GPU once we've compiled the shader, the
+-- type here is entirely phantom - it's just there to make the operations
+-- well typed.
+type Expr :: Type -> Type
+newtype Expr x = Expr {toGLSL :: Syntax.Expr}
+
+-- | Create a @vec4@ from four 'GLfloat' 'Expr' components. This will probably
+-- be replaced with a class in the near future to reflect the different ways in
+-- which GLSL overloads this function.
+vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
+vec4 (toGLSL -> x) (toGLSL -> y) (toGLSL -> z) (toGLSL -> w) = Expr do
+  Syntax.FunctionCall (Syntax.FuncId "vec4") $ Syntax.Params [x, y, z, w]

--- a/shaders/tests/Shader/Expression/ConstantsSpec.hs
+++ b/shaders/tests/Shader/Expression/ConstantsSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Shader.Expression.ConstantsSpec where
+
+import Control.Monad.IO.Class (liftIO)
+import Graphics.Rendering.OpenGL (GLfloat, GLint)
+import Hedgehog (Gen, MonadTest, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helper.Renderer (Renderer, renderExpr)
+import Helper.Roughly (isRoughly)
+import Linear (V4 (V4))
+import Shader.Expression.Constants (fromInteger, fromRational, lift)
+import Shader.Expression.Core (Expr, vec4)
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+import Prelude hiding (fromInteger, fromRational)
+import Prelude qualified
+
+genZeroToOne :: Gen Float
+genZeroToOne = Gen.float (Range.linearFrac 0 1)
+
+spec :: SpecWith Renderer
+spec = do
+  it "lift @GLfloat" \renderer -> hedgehog do
+    input@(V4 x y z w) <- forAll do
+      x <- genZeroToOne
+      y <- genZeroToOne
+      z <- genZeroToOne
+
+      pure $ V4 @GLfloat x y z 1
+
+    output <- liftIO $ renderExpr renderer do
+      vec4 (lift x) (lift y) (lift z) (lift w)
+
+    input `isRoughly` output

--- a/shaders/tests/Shader/Expression/SpecHook.hs
+++ b/shaders/tests/Shader/Expression/SpecHook.hs
@@ -1,0 +1,7 @@
+module Shader.Expression.SpecHook where
+
+import Helper.Renderer (Renderer, withRenderer)
+import Test.Hspec (Spec, SpecWith, around)
+
+hook :: SpecWith Renderer -> Spec
+hook = around withRenderer


### PR DESCRIPTION
For the sake of syntactic brevity, it's nice to be able to write integer- and float-shaped types into GLSL. This can be done with the `Lift` class, and with the specialisations `fromInteger` and `fromRational`, both of which can be used with `RebindableSyntax`.