### PR TITLE
Implement scalar and vector addition

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -6,6 +6,7 @@ library
   exposed-modules:
     Shader.Expression
   other-modules:
+    Shader.Expression.Addition
     Shader.Expression.Constants
     Shader.Expression.Core
     Shader.Expression.Vector
@@ -42,6 +43,8 @@ test-suite shaders-test
   other-modules:
     Shader.Expression
     Shader.Expression.SpecHook
+    Shader.Expression.Addition
+    Shader.Expression.AdditionSpec
     Shader.Expression.Constants
     Shader.Expression.ConstantsSpec
     Shader.Expression.Core

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -10,11 +10,16 @@ module Shader.Expression
     fromRational,
     lift,
 
+    -- * Arithmetic
+    Add,
+    (+),
+
     -- * Vector Constructors
     vec4,
   )
 where
 
+import Shader.Expression.Addition (Add, (+))
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
 import Shader.Expression.Core (Expr (toGLSL))
 import Shader.Expression.Vector (vec4)

--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Typed addition for GLSL.
+module Shader.Expression.Addition where
+
+import Data.Kind (Constraint, Type)
+import Graphics.Rendering.OpenGL (GLfloat)
+import Language.GLSL.Syntax qualified as Syntax
+import Linear (V4)
+import Shader.Expression.Core (Expr (Expr, toGLSL))
+
+-- | Add together two GLSL expressions.
+(+) :: (Add x y z) => Expr x -> Expr y -> Expr z
+(+) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.Add x y)
+
+-- | In GLSL, we can add scalars to vectors and matrices to perform
+-- component-wise changes. Because of this, the output type is computed as a
+-- function of the input types.
+type Add :: Type -> Type -> Type -> Constraint
+class Add left right output | left right -> output
+
+instance Add GLfloat GLfloat GLfloat
+
+instance Add (V4 GLfloat) GLfloat (V4 GLfloat)
+
+instance Add GLfloat (V4 GLfloat) (V4 GLfloat)
+
+instance Add (V4 GLfloat) (V4 GLfloat) (V4 GLfloat)

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -2,10 +2,7 @@
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
-module Shader.Expression.Core
-  ( Expr (Expr, toGLSL),
-  )
-where
+module Shader.Expression.Core where
 
 import Data.Kind (Type)
 import Language.GLSL.Syntax qualified as Syntax

--- a/shaders/tests/Shader/Expression/AdditionSpec.hs
+++ b/shaders/tests/Shader/Expression/AdditionSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Shader.Expression.AdditionSpec where
+
+import Control.Monad.IO.Class (liftIO)
+import Hedgehog (forAll)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helper.Renderer (Renderer, renderExpr)
+import Helper.Roughly (isRoughly)
+import Linear (V4 (V4))
+import Shader.Expression (lift, vec4, (+))
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+import Prelude hiding ((+))
+import Prelude qualified
+
+spec :: SpecWith Renderer
+spec = do
+  it "GLfloat + GLfloat = GLfloat" \renderer -> hedgehog do
+    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+
+    output <- liftIO $ renderExpr renderer do
+      vec4 (lift x1 + lift x2) (lift y) (lift z) (lift 1)
+
+    V4 (x1 Prelude.+ x2) y z 1 `isRoughly` output
+
+  it "V4 GLfloat + GLfloat = V4 GLfloat" \renderer -> hedgehog do
+    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+
+    output <- liftIO $ renderExpr renderer do
+      vec4 (lift x) (lift y) (lift z) (lift (1 - r)) + lift r
+
+    V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
+
+  it "GLfloat + V4 GLfloat = V4 GLfloat" \renderer -> hedgehog do
+    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+
+    output <- liftIO $ renderExpr renderer do
+      lift r + vec4 (lift x) (lift y) (lift z) (lift (1 - r))
+
+    V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
+
+  it "V4 GLfloat + V4 GLfloat = V4 GLfloat" \renderer -> hedgehog do
+    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    y1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    y2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    z1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    z2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+
+    output <- liftIO $ renderExpr renderer do
+      vec4 (lift x1) (lift y1) (lift z1) (lift 0.5)
+        + vec4 (lift x2) (lift y2) (lift z2) (lift 0.5)
+
+    V4 (x1 Prelude.+ x2) (y1 Prelude.+ y2) (z1 Prelude.+ z2) 1 `isRoughly` output


### PR DESCRIPTION
We can do some basic computation! Very exciting. Currently, this is only supported for `vec4` and `float` as we have no way to test results for any other types until we have a way to convert them into a `vec4` to check the output.