### PR TITLE
Implement basic component selection

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -48,6 +48,7 @@ test-suite shaders-test
     Shader.Expression.Constants
     Shader.Expression.ConstantsSpec
     Shader.Expression.Core
+    Shader.Expression.CoreSpec
     Shader.Expression.Vector
     Shader.Expression.VectorSpec
 

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
 module Shader.Expression.Core where
 
 import Data.Kind (Type)
+import GHC.Records (HasField (getField))
 import Language.GLSL.Syntax qualified as Syntax
+import Linear (R1, R2, R3, R4)
 
 -- | An expression is a GLSL value that has a type. In practice, because all
 -- computation will be performed on the GPU once we've compiled the shader, the
@@ -13,3 +19,15 @@ import Language.GLSL.Syntax qualified as Syntax
 -- well typed.
 type Expr :: Type -> Type
 newtype Expr x = Expr {toGLSL :: Syntax.Expr}
+
+instance (x ~ v e, R1 v) => HasField "x" (Expr x) (Expr e) where
+  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "x")
+
+instance (x ~ v e, R2 v) => HasField "y" (Expr x) (Expr e) where
+  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "y")
+
+instance (x ~ v e, R3 v) => HasField "z" (Expr x) (Expr e) where
+  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "z")
+
+instance (x ~ v e, R4 v) => HasField "w" (Expr x) (Expr e) where
+  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "w")

--- a/shaders/tests/Shader/Expression/CoreSpec.hs
+++ b/shaders/tests/Shader/Expression/CoreSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module Shader.Expression.CoreSpec where
+
+import Control.Monad.IO.Class (liftIO)
+import Hedgehog (forAll)
+import Helper.Renderer (Renderer, renderExpr)
+import Helper.RendererSpec (genZeroToOne)
+import Helper.Roughly (isRoughly)
+import Linear (V4 (V4))
+import Shader.Expression (lift, vec4)
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+spec :: SpecWith Renderer
+spec = do
+  it "component selection" \renderer -> hedgehog do
+    x <- forAll genZeroToOne
+    y <- forAll genZeroToOne
+    z <- forAll genZeroToOne
+
+    output <- liftIO $ renderExpr renderer do
+      let input = lift (V4 x y z 1)
+      vec4 input.x input.y input.z input.w
+
+    V4 x y z 1 `isRoughly` output


### PR DESCRIPTION
We're not quite at swizzling yet, but this at least opens the door to talk about types that aren't `vec4` or `float` in tests, and thus in implementations.