### PR TITLE
Add implicit conversion support

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -18,6 +18,7 @@ library
     Shader.Expression
   other-modules:
     Shader.Expression.Addition
+    Shader.Expression.Cast
     Shader.Expression.Constants
     Shader.Expression.Core
     Shader.Expression.Vector
@@ -56,6 +57,8 @@ test-suite shaders-test
     Shader.Expression.SpecHook
     Shader.Expression.Addition
     Shader.Expression.AdditionSpec
+    Shader.Expression.Cast
+    Shader.Expression.CastSpec
     Shader.Expression.Constants
     Shader.Expression.ConstantsSpec
     Shader.Expression.Core

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -10,16 +10,22 @@ module Shader.Expression
     fromRational,
     lift,
 
+    -- * Implicit conversions
+    Cast,
+    cast,
+
+    -- * Vector Constructors
+    ivec4,
+    vec4,
+
     -- * Arithmetic
     Add,
     (+),
-
-    -- * Vector Constructors
-    vec4,
   )
 where
 
 import Shader.Expression.Addition (Add, (+))
+import Shader.Expression.Cast (Cast, cast)
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
 import Shader.Expression.Core (Expr (toGLSL))
-import Shader.Expression.Vector (vec4)
+import Shader.Expression.Vector (ivec4, vec4)

--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -1,0 +1,25 @@
+-- |
+-- A function for an implicit GLSL conversion.
+module Shader.Expression.Cast where
+
+import Data.Coerce (coerce)
+import Data.Kind (Constraint, Type)
+import Graphics.Rendering.OpenGL (GLfloat, GLint)
+import Linear (V4)
+import Shader.Expression.Core (Expr (Expr))
+
+-- | GLSL supports implicit conversions: if a @uint@ is expected and you give
+-- an @int@, then the @int@ can be implicitly converted into a @uint@. Because
+-- we /want/ types, we have to make our implicit conversions... well, explicit.
+-- This should be zero cost: in theory, @cast x@ should have the same GLSL
+-- representation as @x@.
+cast :: (Cast x y) => Expr x -> Expr y
+cast = coerce
+
+-- | Types that can be implicitly converted into other types.
+type Cast :: Type -> Type -> Constraint
+class Cast x y
+
+instance Cast GLint GLfloat
+
+instance (Cast x y) => Cast (V4 x) (V4 y)

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -4,10 +4,15 @@
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
-import Graphics.Rendering.OpenGL (GLfloat)
+import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (V4)
 import Shader.Expression.Core (Expr (Expr, toGLSL))
+
+-- | Construct a @'V4' 'GLint'@ from 'GLint' components.
+ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
+ivec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec4") do
+  Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)

--- a/shaders/tests/Shader/Expression/CastSpec.hs
+++ b/shaders/tests/Shader/Expression/CastSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Shader.Expression.CastSpec where
+
+import Control.Monad.IO.Class (liftIO)
+import Graphics.Rendering.OpenGL (GLfloat, GLint)
+import Hedgehog (forAll)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helper.Renderer (Renderer, renderExpr)
+import Helper.Roughly (isRoughly)
+import Linear (V4 (V4))
+import Shader.Expression (cast, ivec4, lift, vec4)
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+spec :: SpecWith Renderer
+spec = do
+  it "int -> float" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.float (Range.linearFrac 0 1)
+    z <- forAll $ Gen.float (Range.linearFrac 0 1)
+
+    output <- liftIO $ renderExpr renderer do
+      let x' = cast @GLint @GLfloat (lift x)
+      vec4 x' (lift y) (lift z) (lift 1)
+
+    V4 (fromIntegral x) y z 1 `isRoughly` output
+
+  it "V4 int -> V4 float" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+    z <- forAll $ Gen.element [0, 1]
+
+    output <- liftIO $ renderExpr renderer do
+      cast (ivec4 (lift x) (lift y) (lift z) (lift 1))
+
+    fmap fromIntegral (V4 x y z 1) `isRoughly` output


### PR DESCRIPTION
GLSL allows types to be converted to other types implicitly. Jury's out on whether this is a good thing. In any case, we now support implicit conversions in the form of _explicit_ conversions!

This also gives us our first way to talk about non-`float` types as we can convert `int` and `uint` to `float` implicitly. This means our type system has expanded from `float` and `vec4` to `float`, `vec4`, `int`, _and_ `ivec4`! For the sake of testing, I've added an `ivec4` constructor.