### PR TITLE
Add `vec2`, `vec3`, `ivec2`, and `ivec3`

### DIFF
--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -15,7 +15,11 @@ module Shader.Expression
     cast,
 
     -- * Vector Constructors
+    ivec2,
+    ivec3,
     ivec4,
+    vec2,
+    vec3,
     vec4,
 
     -- * Arithmetic
@@ -28,4 +32,4 @@ import Shader.Expression.Addition (Add, (+))
 import Shader.Expression.Cast (Cast, cast)
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
 import Shader.Expression.Core (Expr (toGLSL))
-import Shader.Expression.Vector (ivec4, vec4)
+import Shader.Expression.Vector (ivec2, ivec3, ivec4, vec2, vec3, vec4)

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -6,13 +6,33 @@ module Shader.Expression.Vector where
 
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Language.GLSL.Syntax qualified as Syntax
-import Linear (V4)
+import Linear (V2, V3, V4)
 import Shader.Expression.Core (Expr (Expr, toGLSL))
+
+-- | Construct a @'V2' 'GLint'@ from 'GLint' components.
+ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)
+ivec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec2") do
+  Syntax.Params [toGLSL x, toGLSL y]
+
+-- | Construct a @'V3' 'GLint'@ from 'GLint' components.
+ivec3 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr (V3 GLint)
+ivec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec3") do
+  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
 
 -- | Construct a @'V4' 'GLint'@ from 'GLint' components.
 ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
 ivec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec4") do
   Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
+
+-- | Construct a @'V2' 'GLfloat'@ from 'GLfloat' components.
+vec2 :: Expr GLfloat -> Expr GLfloat -> Expr (V2 GLfloat)
+vec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "vec2") do
+  Syntax.Params [toGLSL x, toGLSL y]
+
+-- | Construct a @'V3' 'GLfloat'@ from 'GLfloat' components.
+vec3 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V3 GLfloat)
+vec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "vec3") do
+  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)

--- a/shaders/tests/Shader/Expression/VectorSpec.hs
+++ b/shaders/tests/Shader/Expression/VectorSpec.hs
@@ -1,21 +1,76 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Shader.Expression.VectorSpec where
 
 import Control.Monad.IO.Class (liftIO)
 import Hedgehog (forAll)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.RendererSpec (genZeroToOne)
 import Helper.Roughly (isRoughly)
 import Linear (V4 (V4))
-import Shader.Expression.Constants (Lift (lift))
-import Shader.Expression.Vector (vec4)
+import Shader.Expression (cast, ivec2, ivec3, ivec4, lift, vec2, vec3, vec4)
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding (fromInteger, fromRational)
 
 spec :: SpecWith Renderer
 spec = do
+  it "ivec2" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+    z <- forAll $ Gen.float (Range.linearFrac 0 1)
+
+    output <- liftIO $ renderExpr renderer do
+      let partial = ivec2 (lift x) (lift y)
+      vec4 (cast partial.x) (cast partial.y) (lift z) (lift 1)
+
+    V4 (fromIntegral x) (fromIntegral y) z 1 `isRoughly` output
+
+  it "ivec3" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+    z <- forAll $ Gen.element [0, 1]
+
+    output <- liftIO $ renderExpr renderer do
+      let partial = ivec3 (lift x) (lift y) (lift z)
+      vec4 (cast partial.x) (cast partial.y) (cast partial.z) (lift 1)
+
+    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+
+  it "ivec4" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+    z <- forAll $ Gen.element [0, 1]
+
+    output <- liftIO $ renderExpr renderer do
+      cast (ivec4 (lift x) (lift y) (lift z) (lift 1))
+
+    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+  it "vec2" \renderer -> hedgehog do
+    x <- forAll genZeroToOne
+    y <- forAll genZeroToOne
+    z <- forAll genZeroToOne
+
+    output <- liftIO $ renderExpr renderer do
+      let partial = vec2 (lift x) (lift y)
+      vec4 partial.x partial.y (lift z) (lift 1)
+
+    V4 x y z 1 `isRoughly` output
+
+  it "vec3" \renderer -> hedgehog do
+    x <- forAll genZeroToOne
+    y <- forAll genZeroToOne
+    z <- forAll genZeroToOne
+
+    output <- liftIO $ renderExpr renderer do
+      let partial = vec3 (lift x) (lift y) (lift z)
+      vec4 partial.x partial.y partial.z (lift 1)
+
+    V4 x y z 1 `isRoughly` output
+
   it "vec4" \renderer -> hedgehog do
     x <- forAll genZeroToOne
     y <- forAll genZeroToOne


### PR DESCRIPTION
Now we have field selection and casts, we can convert other types of vectros into float vectors for testing. At some point, it might be worth thinking about adding more testing renderers for different types, but it's not a priority yet.