### PR TITLE
Remove redundant build components

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - run: |
         cabal update
-        cabal build all --only-dependencies --enable-tests --enable-benchmarks
+        cabal build all --only-dependencies --enable-benchmarks
 
     - run: |
         cabal bench all --enable-tests --enable-benchmarks

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
 
     - run: |
         cabal update
-        cabal build all --only-dependencies --enable-tests --enable-benchmarks
+        cabal build all --only-dependencies --enable-tests
 
     - run: cabal build all --enable-tests
 


### PR DESCRIPTION
We needn't enable tests for benchmarks, and we needn't enable benchmarks for tests. This should hopefully help CI times a little bit.