### PR TITLE
Implement basic boolean logic

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -21,6 +21,7 @@ library
     Shader.Expression.Cast
     Shader.Expression.Constants
     Shader.Expression.Core
+    Shader.Expression.Logic
     Shader.Expression.Vector
   build-depends:
     , base
@@ -63,6 +64,8 @@ test-suite shaders-test
     Shader.Expression.ConstantsSpec
     Shader.Expression.Core
     Shader.Expression.CoreSpec
+    Shader.Expression.Logic
+    Shader.Expression.LogicSpec
     Shader.Expression.Vector
     Shader.Expression.VectorSpec
 

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -15,6 +15,9 @@ module Shader.Expression
     cast,
 
     -- * Vector Constructors
+    bvec2,
+    bvec3,
+    bvec4,
     ivec2,
     ivec3,
     ivec4,
@@ -25,6 +28,13 @@ module Shader.Expression
     -- * Arithmetic
     Add,
     (+),
+
+    -- * Boolean logic
+    true,
+    false,
+    (&&),
+    (||),
+    ifThenElse,
   )
 where
 
@@ -32,4 +42,5 @@ import Shader.Expression.Addition (Add, (+))
 import Shader.Expression.Cast (Cast, cast)
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
 import Shader.Expression.Core (Expr (toGLSL))
-import Shader.Expression.Vector (ivec2, ivec3, ivec4, vec2, vec3, vec4)
+import Shader.Expression.Logic (false, ifThenElse, true, (&&), (||))
+import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- |
 -- Utilities for lifting constants into GLSL.
 module Shader.Expression.Constants
@@ -8,11 +10,11 @@ module Shader.Expression.Constants
 where
 
 import Data.Kind (Constraint, Type)
-import Graphics.Rendering.OpenGL (GLdouble, GLfloat, GLint, GLuint)
+import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (V2 (V2), V3 (V3), V4 (V4))
 import Shader.Expression.Core (Expr (Expr))
-import Shader.Expression.Vector (ivec2, ivec3, ivec4, vec2, vec3, vec4)
+import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)
 import Prelude hiding (fromInteger, fromRational)
 import Prelude qualified
 
@@ -21,6 +23,22 @@ type Lift :: Type -> Constraint
 class Lift x where
   -- | Lift a value into @GLSL@.
   lift :: x -> Expr x
+
+instance Lift GLboolean where
+  -- As defined in the @OpenGLRaw@ package.
+  lift =
+    Expr . \case
+      1 -> Syntax.BoolConstant True
+      _ -> Syntax.BoolConstant False
+
+instance Lift (V2 GLboolean) where
+  lift (V2 x y) = bvec2 (lift x) (lift y)
+
+instance Lift (V3 GLboolean) where
+  lift (V3 x y z) = bvec3 (lift x) (lift y) (lift z)
+
+instance Lift (V4 GLboolean) where
+  lift (V4 x y z w) = bvec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLdouble where
   lift = Expr . Syntax.FloatConstant . realToFrac

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Boolean logic for GLSL.
+module Shader.Expression.Logic where
+
+import Graphics.Rendering.OpenGL (GLboolean)
+import Language.GLSL.Syntax qualified as Syntax
+import Shader.Expression.Core (Expr (Expr), toGLSL)
+
+-- | Boolean 'True'.
+true :: Expr GLboolean
+true = Expr (Syntax.BoolConstant True)
+
+-- | Boolean 'False'.
+false :: Expr GLboolean
+false = Expr (Syntax.BoolConstant False)
+
+-- | Boolean conjunction (@AND@).
+(&&) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
+(&&) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.And x y)
+
+-- | Boolean disjunction (@OR@).
+(||) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
+(||) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.Or x y)
+
+-- | GLSL "selection". When @RebindableSyntax@ is enabled, regular
+-- @if@/@then@/@else@ syntax can compile to this function.
+ifThenElse :: Expr GLboolean -> Expr x -> Expr x -> Expr x
+ifThenElse (toGLSL -> p) (toGLSL -> x) (toGLSL -> y) =
+  Expr (Syntax.Selection p x y)

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -4,10 +4,25 @@
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
-import Graphics.Rendering.OpenGL (GLfloat, GLint)
+import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (V2, V3, V4)
 import Shader.Expression.Core (Expr (Expr, toGLSL))
+
+-- | Construct a @'V2' 'GLboolean'@ from 'GLboolean' components.
+bvec2 :: Expr GLboolean -> Expr GLboolean -> Expr (V2 GLboolean)
+bvec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec2") do
+  Syntax.Params [toGLSL x, toGLSL y]
+
+-- | Construct a @'V3' 'GLboolean'@ from 'GLboolean' components.
+bvec3 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V3 GLboolean)
+bvec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec3") do
+  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
+
+-- | Construct a @'V4' 'GLboolean'@ from 'GLboolean' components.
+bvec4 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V4 GLboolean)
+bvec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec4") do
+  Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
 
 -- | Construct a @'V2' 'GLint'@ from 'GLint' components.
 ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)

--- a/shaders/tests/Shader/Expression/ConstantsSpec.hs
+++ b/shaders/tests/Shader/Expression/ConstantsSpec.hs
@@ -4,14 +4,15 @@
 module Shader.Expression.ConstantsSpec where
 
 import Control.Monad.IO.Class (liftIO)
-import Graphics.Rendering.OpenGL (GLfloat, GLint)
+import Data.Bool (bool)
+import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Hedgehog (Gen, forAll)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.Roughly (isRoughly)
 import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression (Expr, cast, ivec4, lift, vec4)
+import Shader.Expression (Expr, cast, ifThenElse, ivec4, lift, vec4)
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding (fromInteger, fromRational)
@@ -21,6 +22,64 @@ genZeroToOne = Gen.float (Range.linearFrac 0 1)
 
 spec :: SpecWith Renderer
 spec = do
+  let bool2gl :: Bool -> GLboolean
+      bool2gl = bool 0 1
+
+      bool2float :: Bool -> Float
+      bool2float = bool 0 1
+
+      enum :: Expr GLboolean -> Expr GLfloat
+      enum p = ifThenElse p (lift 1) (lift 0)
+
+  it "lift @GLboolean" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr GLboolean
+          partial = lift (bool2gl x)
+
+      vec4 (enum partial) (lift 1) (lift 1) (lift 1)
+
+    V4 (bool2float x) 1 1 1 `isRoughly` output
+
+  it "lift @(V2 GLboolean)" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V2 GLboolean)
+          partial = lift (V2 (bool2gl x) (bool2gl y))
+
+      vec4 (enum partial.x) (enum partial.y) (lift 1) (lift 1)
+
+    V4 (bool2float x) (bool2float y) 1 1 `isRoughly` output
+
+  it "lift @(V3 GLboolean)" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+    z <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V3 GLboolean)
+          partial = lift (V3 (bool2gl x) (bool2gl y) (bool2gl z))
+
+      vec4 (enum partial.x) (enum partial.y) (enum partial.z) (lift 1)
+
+    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+
+  it "lift @(V4 GLboolean)" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+    z <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V4 GLboolean)
+          partial = lift (V4 (bool2gl x) (bool2gl y) (bool2gl z) (bool2gl True))
+
+      vec4 (enum partial.x) (enum partial.y) (enum partial.z) (enum partial.w)
+
+    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+
   it "lift @GLfloat" \renderer -> hedgehog do
     x <- forAll genZeroToOne
     y <- forAll genZeroToOne

--- a/shaders/tests/Shader/Expression/LogicSpec.hs
+++ b/shaders/tests/Shader/Expression/LogicSpec.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+module Shader.Expression.LogicSpec where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Bool (bool)
+import GHC.Records (getField)
+import Graphics.Rendering.OpenGL (GLboolean, GLfloat)
+import Hedgehog (forAll)
+import Hedgehog.Gen qualified as Gen
+import Helper.Renderer (Renderer, renderExpr)
+import Helper.RendererSpec (genZeroToOne)
+import Helper.Roughly (isRoughly, shouldRoughlyBe)
+import Linear (V3 (V3), V4 (V4))
+import Shader.Expression (Expr, false, ifThenElse, lift, true, vec4, (&&), (||))
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+import Prelude hiding ((&&), (||))
+
+spec :: SpecWith Renderer
+spec = do
+  it "selection" \renderer -> hedgehog do
+    p <- forAll Gen.bool
+
+    a <- forAll genZeroToOne
+    b <- forAll genZeroToOne
+    c <- forAll genZeroToOne
+
+    x <- forAll genZeroToOne
+    y <- forAll genZeroToOne
+    z <- forAll genZeroToOne
+
+    output <- liftIO $ renderExpr renderer do
+      let check :: Expr GLboolean
+          check = bool false true p
+
+          partial :: Expr (V3 GLfloat)
+          partial =
+            if check
+              then lift (V3 a b c)
+              else lift (V3 x y z)
+
+      vec4 partial.x partial.y partial.z (lift 1)
+
+    output `isRoughly` bool (V4 x y z 1) (V4 a b c 1) p
+
+  it "conjunction" \renderer -> do
+    let x :: Expr GLfloat
+        x = if false && false then lift 1 else lift 0
+
+        y :: Expr GLfloat
+        y = if false && true then lift 1 else lift 0
+
+        z :: Expr GLfloat
+        z = if true && false then lift 1 else lift 0
+
+        w :: Expr GLfloat
+        w = if true && true then lift 1 else lift 0
+
+    output <- liftIO $ renderExpr renderer (vec4 x y z w)
+    V4 0 0 0 1 `shouldRoughlyBe` output
+
+  it "disjunction" \renderer -> do
+    let x :: Expr GLfloat
+        x = if false || false then lift 1 else lift 0
+
+        y :: Expr GLfloat
+        y = if false || true then lift 1 else lift 0
+
+        z :: Expr GLfloat
+        z = if true || false then lift 1 else lift 0
+
+        w :: Expr GLfloat
+        w = if true || true then lift 1 else lift 0
+
+    output <- liftIO $ renderExpr renderer (vec4 x y z w)
+    V4 0 1 1 1 `shouldRoughlyBe` output

--- a/shaders/tests/Shader/Expression/VectorSpec.hs
+++ b/shaders/tests/Shader/Expression/VectorSpec.hs
@@ -4,28 +4,80 @@
 module Shader.Expression.VectorSpec where
 
 import Control.Monad.IO.Class (liftIO)
+import Data.Bool (bool)
+import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Hedgehog (forAll)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.RendererSpec (genZeroToOne)
 import Helper.Roughly (isRoughly)
-import Linear (V4 (V4))
-import Shader.Expression (cast, ivec2, ivec3, ivec4, lift, vec2, vec3, vec4)
+import Linear (V2, V3, V4 (V4))
+import Shader.Expression (Expr, cast, lift)
+import Shader.Expression qualified as Expr
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding (fromInteger, fromRational)
 
 spec :: SpecWith Renderer
 spec = do
+  let bool2gl :: Bool -> Expr GLboolean
+      bool2gl = bool Expr.false Expr.true
+
+      bool2float :: Bool -> Float
+      bool2float = bool 0 1
+
+      enum :: Expr GLboolean -> Expr GLfloat
+      enum p = Expr.ifThenElse p (lift 1) (lift 0)
+
+  it "bvec2" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V2 GLboolean)
+          partial = Expr.bvec2 (bool2gl x) (bool2gl y)
+
+      Expr.vec4 (enum partial.x) (enum partial.y) (lift 1) (lift 1)
+
+    V4 (bool2float x) (bool2float y) 1 1 `isRoughly` output
+
+  it "bvec3" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+    z <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V3 GLboolean)
+          partial = Expr.bvec3 (bool2gl x) (bool2gl y) (bool2gl z)
+
+      Expr.vec4 (enum partial.x) (enum partial.y) (enum partial.z) (lift 1)
+
+    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+
+  it "bvec4" \renderer -> hedgehog do
+    x <- forAll Gen.bool
+    y <- forAll Gen.bool
+    z <- forAll Gen.bool
+
+    output <- liftIO $ renderExpr renderer do
+      let partial :: Expr (V4 GLboolean)
+          partial = Expr.bvec4 (bool2gl x) (bool2gl y) (bool2gl z) (bool2gl True)
+
+      Expr.vec4 (enum partial.x) (enum partial.y) (enum partial.z) (lift 1)
+
+    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+
   it "ivec2" \renderer -> hedgehog do
     x <- forAll $ Gen.element [0, 1]
     y <- forAll $ Gen.element [0, 1]
     z <- forAll $ Gen.float (Range.linearFrac 0 1)
 
     output <- liftIO $ renderExpr renderer do
-      let partial = ivec2 (lift x) (lift y)
-      vec4 (cast partial.x) (cast partial.y) (lift z) (lift 1)
+      let partial :: Expr (V2 GLint)
+          partial = Expr.ivec2 (lift x) (lift y)
+
+      Expr.vec4 (cast partial.x) (cast partial.y) (lift z) (lift 1)
 
     V4 (fromIntegral x) (fromIntegral y) z 1 `isRoughly` output
 
@@ -35,8 +87,10 @@ spec = do
     z <- forAll $ Gen.element [0, 1]
 
     output <- liftIO $ renderExpr renderer do
-      let partial = ivec3 (lift x) (lift y) (lift z)
-      vec4 (cast partial.x) (cast partial.y) (cast partial.z) (lift 1)
+      let partial :: Expr (V3 GLint)
+          partial = Expr.ivec3 (lift x) (lift y) (lift z)
+
+      Expr.vec4 (cast partial.x) (cast partial.y) (cast partial.z) (lift 1)
 
     fmap fromIntegral (V4 x y z 1) `isRoughly` output
 
@@ -46,17 +100,20 @@ spec = do
     z <- forAll $ Gen.element [0, 1]
 
     output <- liftIO $ renderExpr renderer do
-      cast (ivec4 (lift x) (lift y) (lift z) (lift 1))
+      cast (Expr.ivec4 (lift x) (lift y) (lift z) (lift 1))
 
     fmap fromIntegral (V4 x y z 1) `isRoughly` output
+
   it "vec2" \renderer -> hedgehog do
     x <- forAll genZeroToOne
     y <- forAll genZeroToOne
     z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      let partial = vec2 (lift x) (lift y)
-      vec4 partial.x partial.y (lift z) (lift 1)
+      let partial :: Expr (V2 GLfloat)
+          partial = Expr.vec2 (lift x) (lift y)
+
+      Expr.vec4 partial.x partial.y (lift z) (lift 1)
 
     V4 x y z 1 `isRoughly` output
 
@@ -66,8 +123,10 @@ spec = do
     z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      let partial = vec3 (lift x) (lift y) (lift z)
-      vec4 partial.x partial.y partial.z (lift 1)
+      let partial :: Expr (V3 GLfloat)
+          partial = Expr.vec3 (lift x) (lift y) (lift z)
+
+      Expr.vec4 partial.x partial.y partial.z (lift 1)
 
     V4 x y z 1 `isRoughly` output
 
@@ -77,6 +136,6 @@ spec = do
     z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      vec4 (lift x) (lift y) (lift z) (lift 1)
+      Expr.vec4 (lift x) (lift y) (lift z) (lift 1)
 
     V4 x y z 1 `isRoughly` output


### PR DESCRIPTION
This PR implements conditional branching, conjunction, disjunction, and even rebindable syntax for `ifThenElse`. There's also now support for `bvec2`, `bvec3`, and `bvec4`, and all these can be lifted from `linear` vector types.