### PR TITLE
Make the AST explicit rather than delegating to `language-glsl`

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -25,6 +25,7 @@ library
     Shader.Expression.Vector
   build-depends:
     , base
+    , data-fix
     , language-glsl
     , linear
     , OpenGL
@@ -41,6 +42,7 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
+    , data-fix
     , hedgehog
     , hspec
     , hspec-hedgehog

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -3,7 +3,8 @@
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
 module Shader.Expression
-  ( Expr (toGLSL),
+  ( Expr,
+    toGLSL,
 
     -- * GLSL Embedding
     fromInteger,
@@ -41,6 +42,6 @@ where
 import Shader.Expression.Addition (Add, (+))
 import Shader.Expression.Cast (Cast, cast)
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
-import Shader.Expression.Core (Expr (toGLSL))
+import Shader.Expression.Core (Expr, toGLSL)
 import Shader.Expression.Logic (false, ifThenElse, true, (&&), (||))
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)

--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -6,15 +6,15 @@
 -- Typed addition for GLSL.
 module Shader.Expression.Addition where
 
+import Data.Fix (Fix (Fix))
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat)
-import Language.GLSL.Syntax qualified as Syntax
 import Linear (V4)
-import Shader.Expression.Core (Expr (Expr, toGLSL))
+import Shader.Expression.Core (Expr (Expr, toAST), Expression (Add))
 
 -- | Add together two GLSL expressions.
 (+) :: (Add x y z) => Expr x -> Expr y -> Expr z
-(+) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.Add x y)
+(+) (toAST -> x) (toAST -> y) = Expr (Fix (Add x y))
 
 -- | In GLSL, we can add scalars to vectors and matrices to perform
 -- component-wise changes. Because of this, the output type is computed as a

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -9,11 +9,11 @@ module Shader.Expression.Constants
   )
 where
 
+import Data.Fix (Fix (Fix))
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
-import Language.GLSL.Syntax qualified as Syntax
 import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression.Core (Expr (Expr))
+import Shader.Expression.Core (Expr (Expr), Expression (BoolConstant, FloatConstant, IntConstant))
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)
 import Prelude hiding (fromInteger, fromRational)
 import Prelude qualified
@@ -27,9 +27,9 @@ class Lift x where
 instance Lift GLboolean where
   -- As defined in the @OpenGLRaw@ package.
   lift =
-    Expr . \case
-      1 -> Syntax.BoolConstant True
-      _ -> Syntax.BoolConstant False
+    Expr . Fix . \case
+      1 -> BoolConstant True
+      _ -> BoolConstant False
 
 instance Lift (V2 GLboolean) where
   lift (V2 x y) = bvec2 (lift x) (lift y)
@@ -41,10 +41,10 @@ instance Lift (V4 GLboolean) where
   lift (V4 x y z w) = bvec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLdouble where
-  lift = Expr . Syntax.FloatConstant . realToFrac
+  lift = Expr . Fix . FloatConstant . realToFrac
 
 instance Lift GLfloat where
-  lift = Expr . Syntax.FloatConstant
+  lift = Expr . Fix . FloatConstant
 
 instance Lift (V2 GLfloat) where
   lift (V2 x y) = vec2 (lift x) (lift y)
@@ -56,7 +56,7 @@ instance Lift (V4 GLfloat) where
   lift (V4 x y z w) = vec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLint where
-  lift = Expr . Syntax.IntConstant Syntax.Decimal . fromIntegral
+  lift = Expr . Fix . IntConstant . fromIntegral
 
 instance Lift (V2 GLint) where
   lift (V2 x y) = ivec2 (lift x) (lift y)
@@ -68,7 +68,7 @@ instance Lift (V4 GLint) where
   lift (V4 x y z w) = ivec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLuint where
-  lift = Expr . Syntax.IntConstant Syntax.Decimal . fromIntegral
+  lift = Expr . Fix . IntConstant . fromIntegral
 
 -- | @RebindableSyntax@ function for integer literals.
 fromInteger :: (Lift x, Num x) => Integer -> Expr x

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -1,13 +1,14 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
 module Shader.Expression.Core where
 
+import Data.Fix (Fix (Fix))
 import Data.Kind (Type)
 import GHC.Records (HasField (getField))
 import Language.GLSL.Syntax qualified as Syntax
@@ -18,16 +19,73 @@ import Linear (R1, R2, R3, R4)
 -- type here is entirely phantom - it's just there to make the operations
 -- well typed.
 type Expr :: Type -> Type
-newtype Expr x = Expr {toGLSL :: Syntax.Expr}
+newtype Expr x = Expr {toAST :: Fix Expression}
+
+-- | We define the expression language using the 'Fix' point of this functor.
+-- This allows us to annotate the AST later with other annotations such as
+-- types.
+type Expression :: Type -> Type
+data Expression inner
+  = -- | A constant value displayed as an integer. This could be an @int@, but
+    -- it could also be a @uint@ or any other type that can be given as an
+    -- integral constant.
+    IntConstant Integer
+  | -- | A constant vvalue displayed as a floating point number. This should
+    -- either be a @float@ or a @double@.
+    FloatConstant Float
+  | -- | A boolean value of type @boolean@.
+    BoolConstant Bool
+  | -- | A single field within a vector, or a swizzling mask.
+    FieldSelection String inner
+  | -- | A call to the given function name with the given arguments.
+    FunctionCall String [inner]
+  | -- | Arithmetic sum, which compiles to the GLSL @+@.
+    Add inner inner
+  | -- | Logical AND operation, which compiles to the GLSL @&&@.
+    And inner inner
+  | -- | Logical OR operation, which compiles to the GLSL @&&@.
+    Or inner inner
+  | -- | Boolean selection, which is represented in GLSL with @?@ and @:@. Maps
+    -- exactly to Haskell's @ifThenElse@ construction.
+    Selection inner inner inner
+  deriving stock (Eq, Ord, Functor, Show)
 
 instance (R1 v) => HasField "x" (Expr (v e)) (Expr e) where
-  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "x")
+  getField = Expr . Fix . FieldSelection "x" . toAST
 
 instance (R2 v) => HasField "y" (Expr (v e)) (Expr e) where
-  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "y")
+  getField = Expr . Fix . FieldSelection "y" . toAST
 
 instance (R3 v) => HasField "z" (Expr (v e)) (Expr e) where
-  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "z")
+  getField = Expr . Fix . FieldSelection "z" . toAST
 
 instance (R4 v) => HasField "w" (Expr (v e)) (Expr e) where
-  getField (toGLSL -> xs) = Expr (Syntax.FieldSelection xs "w")
+  getField = Expr . Fix . FieldSelection "w" . toAST
+
+-- | Convert a Haskell expression into a GLSL abstract syntax tree. This
+-- performs no type-checking and is extremely naïve, so optimisations and AST
+-- passes should be done before this call.
+toGLSL :: Expr x -> Syntax.Expr
+toGLSL = go . toAST
+  where
+    go :: Fix Expression -> Syntax.Expr
+    go (Fix expr) = case expr of
+      BoolConstant x ->
+        Syntax.BoolConstant x
+      FloatConstant x ->
+        Syntax.FloatConstant x
+      IntConstant x ->
+        Syntax.IntConstant Syntax.Decimal x
+      Add x y ->
+        Syntax.Add (go x) (go y)
+      And x y ->
+        Syntax.And (go x) (go y)
+      Or x y ->
+        Syntax.Or (go x) (go y)
+      FieldSelection s xs ->
+        Syntax.FieldSelection (go xs) s
+      FunctionCall f xs ->
+        Syntax.FunctionCall (Syntax.FuncId f) do
+          Syntax.Params (map go xs)
+      Selection p x y ->
+        Syntax.Selection (go p) (go x) (go y)

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -5,28 +5,27 @@
 -- Boolean logic for GLSL.
 module Shader.Expression.Logic where
 
+import Data.Fix (Fix (Fix))
 import Graphics.Rendering.OpenGL (GLboolean)
-import Language.GLSL.Syntax qualified as Syntax
-import Shader.Expression.Core (Expr (Expr), toGLSL)
+import Shader.Expression.Core (Expr (Expr, toAST), Expression (And, BoolConstant, Or, Selection))
 
 -- | Boolean 'True'.
 true :: Expr GLboolean
-true = Expr (Syntax.BoolConstant True)
+true = Expr (Fix (BoolConstant True))
 
 -- | Boolean 'False'.
 false :: Expr GLboolean
-false = Expr (Syntax.BoolConstant False)
+false = Expr (Fix (BoolConstant False))
 
 -- | Boolean conjunction (@AND@).
 (&&) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(&&) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.And x y)
+(&&) (toAST -> x) (toAST -> y) = Expr (Fix (And x y))
 
 -- | Boolean disjunction (@OR@).
 (||) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(||) (toGLSL -> x) (toGLSL -> y) = Expr (Syntax.Or x y)
+(||) (toAST -> x) (toAST -> y) = Expr (Fix (Or x y))
 
--- | GLSL "selection". When @RebindableSyntax@ is enabled, regular
+-- | AST "selection". When @RebindableSyntax@ is enabled, regular
 -- @if@/@then@/@else@ syntax can compile to this function.
 ifThenElse :: Expr GLboolean -> Expr x -> Expr x -> Expr x
-ifThenElse (toGLSL -> p) (toGLSL -> x) (toGLSL -> y) =
-  Expr (Syntax.Selection p x y)
+ifThenElse (toAST -> p) (toAST -> x) (toAST -> y) = Expr (Fix (Selection p x y))

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -1,55 +1,47 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
+import Data.Fix (Fix (Fix))
 import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
-import Language.GLSL.Syntax qualified as Syntax
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (Expr, toGLSL))
+import Shader.Expression.Core (Expr (Expr, toAST), Expression (FunctionCall))
 
 -- | Construct a @'V2' 'GLboolean'@ from 'GLboolean' components.
 bvec2 :: Expr GLboolean -> Expr GLboolean -> Expr (V2 GLboolean)
-bvec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec2") do
-  Syntax.Params [toGLSL x, toGLSL y]
+bvec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "bvec2" [x, y]))
 
 -- | Construct a @'V3' 'GLboolean'@ from 'GLboolean' components.
 bvec3 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V3 GLboolean)
-bvec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec3") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
+bvec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "bvec3" [x, y, z]))
 
 -- | Construct a @'V4' 'GLboolean'@ from 'GLboolean' components.
 bvec4 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V4 GLboolean)
-bvec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "bvec4") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
+bvec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "bvec4" [x, y, z, w]))
 
 -- | Construct a @'V2' 'GLint'@ from 'GLint' components.
 ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)
-ivec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec2") do
-  Syntax.Params [toGLSL x, toGLSL y]
+ivec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "ivec2" [x, y]))
 
 -- | Construct a @'V3' 'GLint'@ from 'GLint' components.
 ivec3 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr (V3 GLint)
-ivec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec3") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
+ivec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "ivec3" [x, y, z]))
 
 -- | Construct a @'V4' 'GLint'@ from 'GLint' components.
 ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
-ivec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "ivec4") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
+ivec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "ivec4" [x, y, z, w]))
 
 -- | Construct a @'V2' 'GLfloat'@ from 'GLfloat' components.
 vec2 :: Expr GLfloat -> Expr GLfloat -> Expr (V2 GLfloat)
-vec2 x y = Expr $ Syntax.FunctionCall (Syntax.FuncId "vec2") do
-  Syntax.Params [toGLSL x, toGLSL y]
+vec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "vec2" [x, y]))
 
 -- | Construct a @'V3' 'GLfloat'@ from 'GLfloat' components.
 vec3 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V3 GLfloat)
-vec3 x y z = Expr $ Syntax.FunctionCall (Syntax.FuncId "vec3") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z]
+vec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "vec3" [x, y, z]))
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
-vec4 x y z w = Expr $ Syntax.FunctionCall (Syntax.FuncId "vec4") do
-  Syntax.Params [toGLSL x, toGLSL y, toGLSL z, toGLSL w]
+vec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "vec4" [x, y, z, w]))

--- a/shaders/tests/Helper/Renderer.hs
+++ b/shaders/tests/Helper/Renderer.hs
@@ -32,7 +32,7 @@ import Graphics.Rendering.OpenGL qualified as GL
 import Language.GLSL.Pretty ()
 import Linear (V2 (V2), V4)
 import SDL qualified
-import Shader.Expression (Expr (toGLSL))
+import Shader.Expression (Expr, toGLSL)
 import Text.PrettyPrint.HughesPJClass (prettyShow)
 
 -- | A 'Renderer' allows you to test a fragment shader. Given the source code


### PR DESCRIPTION
Previously, the expression type was a newtype around `language-glsl`'s `Expr` type. This was very convenient as the compile step was... well, unwrapping a newtype. However, it's limiting for a number of reasons.

The big one we're about to care about is that we want to annotate nodes in the tree with type information so that we can factor out common expressions into intermediate bindings. `language-glsl` (understandably) doesn't carry around any sort of type information, so we need a type that does.

It also means we can remove _some_ of the noise around the GLSL constructors at least in the intermediate stages.