### PR TITLE
Add a convenience function for lifting `Expression` into `Expr`

### DIFF
--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -6,15 +6,14 @@
 -- Typed addition for GLSL.
 module Shader.Expression.Addition where
 
-import Data.Fix (Fix (Fix))
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat)
 import Linear (V4)
-import Shader.Expression.Core (Expr (Expr, toAST), Expression (Add))
+import Shader.Expression.Core (Expr (toAST), Expression (Add), expr_)
 
 -- | Add together two GLSL expressions.
 (+) :: (Add x y z) => Expr x -> Expr y -> Expr z
-(+) (toAST -> x) (toAST -> y) = Expr (Fix (Add x y))
+(+) (toAST -> x) (toAST -> y) = expr_ (Add x y)
 
 -- | In GLSL, we can add scalars to vectors and matrices to perform
 -- component-wise changes. Because of this, the output type is computed as a

--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -6,7 +6,7 @@ import Data.Coerce (coerce)
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Linear (V4)
-import Shader.Expression.Core (Expr (Expr))
+import Shader.Expression.Core (Expr)
 
 -- | GLSL supports implicit conversions: if a @uint@ is expected and you give
 -- an @int@, then the @int@ can be implicitly converted into a @uint@. Because

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -9,11 +9,10 @@ module Shader.Expression.Constants
   )
 where
 
-import Data.Fix (Fix (Fix))
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
 import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression.Core (Expr (Expr), Expression (BoolConstant, FloatConstant, IntConstant))
+import Shader.Expression.Core (Expr, Expression (BoolConstant, FloatConstant, IntConstant), expr_)
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)
 import Prelude hiding (fromInteger, fromRational)
 import Prelude qualified
@@ -27,7 +26,7 @@ class Lift x where
 instance Lift GLboolean where
   -- As defined in the @OpenGLRaw@ package.
   lift =
-    Expr . Fix . \case
+    expr_ . \case
       1 -> BoolConstant True
       _ -> BoolConstant False
 
@@ -41,10 +40,10 @@ instance Lift (V4 GLboolean) where
   lift (V4 x y z w) = bvec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLdouble where
-  lift = Expr . Fix . FloatConstant . realToFrac
+  lift = expr_ . FloatConstant . realToFrac
 
 instance Lift GLfloat where
-  lift = Expr . Fix . FloatConstant
+  lift = expr_ . FloatConstant
 
 instance Lift (V2 GLfloat) where
   lift (V2 x y) = vec2 (lift x) (lift y)
@@ -56,7 +55,7 @@ instance Lift (V4 GLfloat) where
   lift (V4 x y z w) = vec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLint where
-  lift = Expr . Fix . IntConstant . fromIntegral
+  lift = expr_ . IntConstant . fromIntegral
 
 instance Lift (V2 GLint) where
   lift (V2 x y) = ivec2 (lift x) (lift y)
@@ -68,7 +67,7 @@ instance Lift (V4 GLint) where
   lift (V4 x y z w) = ivec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLuint where
-  lift = Expr . Fix . IntConstant . fromIntegral
+  lift = expr_ . IntConstant . fromIntegral
 
 -- | @RebindableSyntax@ function for integer literals.
 fromInteger :: (Lift x, Num x) => Integer -> Expr x

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -7,7 +7,14 @@
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
-module Shader.Expression.Core where
+module Shader.Expression.Core
+  ( Expr,
+    expr_,
+    Expression (..),
+    toAST,
+    toGLSL,
+  )
+where
 
 import Data.Fix (Fix (Fix))
 import Data.Functor.Foldable (cata)
@@ -22,6 +29,10 @@ import Linear (R1, R2, R3, R4)
 -- well typed.
 type Expr :: Type -> Type
 newtype Expr x = Expr {toAST :: Fix Expression}
+
+-- | A convenience function for lifting an expression into 'Expr'.
+expr_ :: Expression (Fix Expression) -> Expr x
+expr_ = Expr . Fix
 
 -- | We define the expression language using the 'Fix' point of this functor.
 -- This allows us to annotate the AST later with other annotations such as

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -5,27 +5,26 @@
 -- Boolean logic for GLSL.
 module Shader.Expression.Logic where
 
-import Data.Fix (Fix (Fix))
 import Graphics.Rendering.OpenGL (GLboolean)
-import Shader.Expression.Core (Expr (Expr, toAST), Expression (And, BoolConstant, Or, Selection))
+import Shader.Expression.Core (Expr (toAST), Expression (And, BoolConstant, Or, Selection), expr_)
 
 -- | Boolean 'True'.
 true :: Expr GLboolean
-true = Expr (Fix (BoolConstant True))
+true = expr_ (BoolConstant True)
 
 -- | Boolean 'False'.
 false :: Expr GLboolean
-false = Expr (Fix (BoolConstant False))
+false = expr_ (BoolConstant False)
 
 -- | Boolean conjunction (@AND@).
 (&&) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(&&) (toAST -> x) (toAST -> y) = Expr (Fix (And x y))
+(&&) (toAST -> x) (toAST -> y) = expr_ (And x y)
 
 -- | Boolean disjunction (@OR@).
 (||) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(||) (toAST -> x) (toAST -> y) = Expr (Fix (Or x y))
+(||) (toAST -> x) (toAST -> y) = expr_ (Or x y)
 
 -- | AST "selection". When @RebindableSyntax@ is enabled, regular
 -- @if@/@then@/@else@ syntax can compile to this function.
 ifThenElse :: Expr GLboolean -> Expr x -> Expr x -> Expr x
-ifThenElse (toAST -> p) (toAST -> x) (toAST -> y) = Expr (Fix (Selection p x y))
+ifThenElse (toAST -> p) (toAST -> x) (toAST -> y) = expr_ (Selection p x y)

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -5,43 +5,42 @@
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
-import Data.Fix (Fix (Fix))
 import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (Expr, toAST), Expression (FunctionCall))
+import Shader.Expression.Core (Expr (toAST), Expression (FunctionCall), expr_)
 
 -- | Construct a @'V2' 'GLboolean'@ from 'GLboolean' components.
 bvec2 :: Expr GLboolean -> Expr GLboolean -> Expr (V2 GLboolean)
-bvec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "bvec2" [x, y]))
+bvec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "bvec2" [x, y])
 
 -- | Construct a @'V3' 'GLboolean'@ from 'GLboolean' components.
 bvec3 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V3 GLboolean)
-bvec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "bvec3" [x, y, z]))
+bvec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "bvec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLboolean'@ from 'GLboolean' components.
 bvec4 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V4 GLboolean)
-bvec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "bvec4" [x, y, z, w]))
+bvec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "bvec4" [x, y, z, w])
 
 -- | Construct a @'V2' 'GLint'@ from 'GLint' components.
 ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)
-ivec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "ivec2" [x, y]))
+ivec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "ivec2" [x, y])
 
 -- | Construct a @'V3' 'GLint'@ from 'GLint' components.
 ivec3 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr (V3 GLint)
-ivec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "ivec3" [x, y, z]))
+ivec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "ivec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLint'@ from 'GLint' components.
 ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
-ivec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "ivec4" [x, y, z, w]))
+ivec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "ivec4" [x, y, z, w])
 
 -- | Construct a @'V2' 'GLfloat'@ from 'GLfloat' components.
 vec2 :: Expr GLfloat -> Expr GLfloat -> Expr (V2 GLfloat)
-vec2 (toAST -> x) (toAST -> y) = Expr (Fix (FunctionCall "vec2" [x, y]))
+vec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "vec2" [x, y])
 
 -- | Construct a @'V3' 'GLfloat'@ from 'GLfloat' components.
 vec3 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V3 GLfloat)
-vec3 (toAST -> x) (toAST -> y) (toAST -> z) = Expr (Fix (FunctionCall "vec3" [x, y, z]))
+vec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "vec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
-vec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = Expr (Fix (FunctionCall "vec4" [x, y, z, w]))
+vec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "vec4" [x, y, z, w])


### PR DESCRIPTION
As well as removing some mentions of `Fix` in the codebase, this also means that if (when) we want to replace `Fix` with, say, `Cofree`, we won't have to change as much code.