### PR TITLE
Annotate the AST with GLSL types

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -22,10 +22,11 @@ library
     Shader.Expression.Constants
     Shader.Expression.Core
     Shader.Expression.Logic
+    Shader.Expression.Type
     Shader.Expression.Vector
   build-depends:
     , base
-    , data-fix
+    , free
     , language-glsl
     , linear
     , OpenGL
@@ -43,7 +44,7 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
-    , data-fix
+    , free
     , hedgehog
     , hspec
     , hspec-hedgehog
@@ -70,6 +71,7 @@ test-suite shaders-test
     Shader.Expression.CoreSpec
     Shader.Expression.Logic
     Shader.Expression.LogicSpec
+    Shader.Expression.Type
     Shader.Expression.Vector
     Shader.Expression.VectorSpec
 

--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -10,9 +10,10 @@ import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat)
 import Linear (V4)
 import Shader.Expression.Core (Expr (toAST), Expression (Add), expr_)
+import Shader.Expression.Type (Typed)
 
 -- | Add together two GLSL expressions.
-(+) :: (Add x y z) => Expr x -> Expr y -> Expr z
+(+) :: (Add x y z, Typed z) => Expr x -> Expr y -> Expr z
 (+) (toAST -> x) (toAST -> y) = expr_ (Add x y)
 
 -- | In GLSL, we can add scalars to vectors and matrices to perform

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -7,6 +7,7 @@ module Shader.Expression.Logic where
 
 import Graphics.Rendering.OpenGL (GLboolean)
 import Shader.Expression.Core (Expr (toAST), Expression (And, BoolConstant, Or, Selection), expr_)
+import Shader.Expression.Type (Typed)
 
 -- | Boolean 'True'.
 true :: Expr GLboolean
@@ -26,5 +27,5 @@ false = expr_ (BoolConstant False)
 
 -- | AST "selection". When @RebindableSyntax@ is enabled, regular
 -- @if@/@then@/@else@ syntax can compile to this function.
-ifThenElse :: Expr GLboolean -> Expr x -> Expr x -> Expr x
+ifThenElse :: (Typed x) => Expr GLboolean -> Expr x -> Expr x -> Expr x
 ifThenElse (toAST -> p) (toAST -> x) (toAST -> y) = expr_ (Selection p x y)

--- a/shaders/source/Shader/Expression/Type.hs
+++ b/shaders/source/Shader/Expression/Type.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+
+-- | Types of values within GLSL.
+module Shader.Expression.Type where
+
+import Data.Kind (Constraint, Type)
+import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
+import Language.GLSL.Syntax qualified as Syntax
+import Linear (V2, V3, V4)
+
+-- | In order to compute intermediate results in GLSL, we need to define types
+-- for them. This class defines a syntactical representation of a value's type
+-- within GLSL.
+type Typed :: Type -> Constraint
+class Typed x where
+  -- | What is the GLSL type declaration for this type? Meant to be used with
+  -- type applications, i.e. @typeOf @GLdouble@.
+  typeOf :: Syntax.TypeSpecifier
+
+instance Typed GLboolean where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Float Nothing
+
+instance Typed GLdouble where
+  typeOf = Syntax.TypeSpec (Just Syntax.HighP) do
+    Syntax.TypeSpecNoPrecision Syntax.Float Nothing
+
+instance Typed GLfloat where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Float Nothing
+
+instance Typed GLint where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Float Nothing
+
+instance Typed GLuint where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.UInt Nothing
+
+instance Typed (V2 GLboolean) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec2 Nothing
+
+instance Typed (V3 GLboolean) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec3 Nothing
+
+instance Typed (V4 GLboolean) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec4 Nothing
+
+instance Typed (V2 GLfloat) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec2 Nothing
+
+instance Typed (V3 GLfloat) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec3 Nothing
+
+instance Typed (V4 GLfloat) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.Vec4 Nothing
+
+instance Typed (V2 GLint) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.IVec2 Nothing
+
+instance Typed (V3 GLint) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.IVec3 Nothing
+
+instance Typed (V4 GLint) where
+  typeOf = Syntax.TypeSpec Nothing do
+    Syntax.TypeSpecNoPrecision Syntax.IVec4 Nothing


### PR DESCRIPTION
The primary reason for needing this is that we'll want to compute intermediate results in GLSL programs to avoid unnecessary duplicated work. To declare a variable in GLSL, it needs a type. So, now we can get a type for every expression in our EDSL.