### PR TITLE
Add an explicit constructor for `Cast`

### DIFF
--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -1,20 +1,22 @@
+{-# LANGUAGE ViewPatterns #-}
+
 -- |
 -- A function for an implicit GLSL conversion.
 module Shader.Expression.Cast where
 
-import Data.Coerce (coerce)
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Linear (V4)
-import Shader.Expression.Core (Expr)
+import Shader.Expression.Core (Expr, Expression (Cast), expr_, toAST)
+import Shader.Expression.Type (Typed)
 
 -- | GLSL supports implicit conversions: if a @uint@ is expected and you give
 -- an @int@, then the @int@ can be implicitly converted into a @uint@. Because
 -- we /want/ types, we have to make our implicit conversions... well, explicit.
 -- This should be zero cost: in theory, @cast x@ should have the same GLSL
 -- representation as @x@.
-cast :: (Cast x y) => Expr x -> Expr y
-cast = coerce
+cast :: (Cast x y, Typed y) => Expr x -> Expr y
+cast (toAST -> x) = expr_ (Cast x)
 
 -- | Types that can be implicitly converted into other types.
 type Cast :: Type -> Type -> Constraint

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -48,6 +48,8 @@ data Expression inner
     FloatConstant Float
   | -- | A boolean value of type @boolean@.
     BoolConstant Bool
+  | -- | Implicit GLSL type conversion.
+    Cast inner
   | -- | A single field within a vector, or a swizzling mask.
     FieldSelection String inner
   | -- | A call to the given function name with the given arguments.
@@ -86,6 +88,7 @@ toGLSL = go . toAST
       BoolConstant x -> Syntax.BoolConstant x
       FloatConstant x -> Syntax.FloatConstant x
       IntConstant x -> Syntax.IntConstant Syntax.Decimal x
+      Cast x -> x
       Add x y -> Syntax.Add x y
       And x y -> Syntax.And x y
       Or x y -> Syntax.Or x y


### PR DESCRIPTION
In theory, this should make no difference - we might end up with expressions been given a pre-conversion type rather than a post-conversion one, but the conversion should implicitly happen afterwards anyway. In any case, this is more correct.