### PR TITLE
Convert `Expr` to a straightforward GADT

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -26,11 +26,10 @@ library
     Shader.Expression.Vector
   build-depends:
     , base
-    , free
     , language-glsl
     , linear
     , OpenGL
-    , recursion-schemes
+    , some
   ghc-options: -Wall -Wextra
   hs-source-dirs: source
   default-language: GHC2021
@@ -44,7 +43,6 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
-    , free
     , hedgehog
     , hspec
     , hspec-hedgehog
@@ -52,9 +50,9 @@ test-suite shaders-test
     , linear
     , OpenGL
     , prettyclass
-    , recursion-schemes
     , sdl2
     , shaders
+    , some
     , string-interpolate
   build-tool-depends:
     hspec-discover:hspec-discover

--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Typed addition for GLSL.
@@ -9,12 +8,12 @@ module Shader.Expression.Addition where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat)
 import Linear (V4)
-import Shader.Expression.Core (Expr (toAST), Expression (Add), expr_)
+import Shader.Expression.Core (Expr (Add))
 import Shader.Expression.Type (Typed)
 
 -- | Add together two GLSL expressions.
 (+) :: (Add x y z, Typed z) => Expr x -> Expr y -> Expr z
-(+) (toAST -> x) (toAST -> y) = expr_ (Add x y)
+(+) = Add
 
 -- | In GLSL, we can add scalars to vectors and matrices to perform
 -- component-wise changes. Because of this, the output type is computed as a

--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ViewPatterns #-}
-
 -- |
 -- A function for an implicit GLSL conversion.
 module Shader.Expression.Cast where
@@ -7,7 +5,7 @@ module Shader.Expression.Cast where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Linear (V4)
-import Shader.Expression.Core (Expr, Expression (Cast), expr_, toAST)
+import Shader.Expression.Core (Expr (Cast))
 import Shader.Expression.Type (Typed)
 
 -- | GLSL supports implicit conversions: if a @uint@ is expected and you give
@@ -16,7 +14,7 @@ import Shader.Expression.Type (Typed)
 -- This should be zero cost: in theory, @cast x@ should have the same GLSL
 -- representation as @x@.
 cast :: (Cast x y, Typed y) => Expr x -> Expr y
-cast (toAST -> x) = expr_ (Cast x)
+cast = Cast
 
 -- | Types that can be implicitly converted into other types.
 type Cast :: Type -> Type -> Constraint

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -12,7 +12,7 @@ where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
 import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression.Core (Expr, Expression (BoolConstant, FloatConstant, IntConstant), expr_)
+import Shader.Expression.Core (Expr (BoolConstant, Cast, FloatConstant, IntConstant))
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)
 import Prelude hiding (fromInteger, fromRational)
 import Prelude qualified
@@ -26,9 +26,9 @@ class Lift x where
 instance Lift GLboolean where
   -- As defined in the @OpenGLRaw@ package.
   lift =
-    expr_ . \case
-      1 -> BoolConstant True
-      _ -> BoolConstant False
+    BoolConstant . \case
+      1 -> True
+      _ -> False
 
 instance Lift (V2 GLboolean) where
   lift (V2 x y) = bvec2 (lift x) (lift y)
@@ -40,10 +40,10 @@ instance Lift (V4 GLboolean) where
   lift (V4 x y z w) = bvec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLdouble where
-  lift = expr_ . FloatConstant . realToFrac
+  lift = Cast . FloatConstant . realToFrac
 
 instance Lift GLfloat where
-  lift = expr_ . FloatConstant
+  lift = FloatConstant
 
 instance Lift (V2 GLfloat) where
   lift (V2 x y) = vec2 (lift x) (lift y)
@@ -55,7 +55,7 @@ instance Lift (V4 GLfloat) where
   lift (V4 x y z w) = vec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLint where
-  lift = expr_ . IntConstant . fromIntegral
+  lift = IntConstant . fromIntegral
 
 instance Lift (V2 GLint) where
   lift (V2 x y) = ivec2 (lift x) (lift y)
@@ -67,7 +67,7 @@ instance Lift (V4 GLint) where
   lift (V4 x y z w) = ivec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLuint where
-  lift = expr_ . IntConstant . fromIntegral
+  lift = Cast . IntConstant . fromIntegral
 
 -- | @RebindableSyntax@ function for integer literals.
 fromInteger :: (Lift x, Num x) => Integer -> Expr x

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -1,97 +1,83 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
 module Shader.Expression.Core
-  ( Expr,
-    expr_,
-    Expression (..),
-    toAST,
+  ( Expr (..),
     toGLSL,
   )
 where
 
-import Control.Comonad.Cofree (Cofree ((:<)))
-import Control.Comonad.Trans.Cofree qualified as CofreeF
-import Data.Functor.Foldable (cata)
 import Data.Kind (Type)
+import Data.Some (Some)
+import Data.Some qualified as Some
 import GHC.Records (HasField (getField))
+import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (R1, R2, R3, R4)
-import Shader.Expression.Type (Typed (typeOf))
+import Shader.Expression.Type (Typed)
 
 -- | An expression is a GLSL value that has a type. We keep track of the type
 -- of the expression and all its subexpressions in case we want to factor them
 -- out as intermediate bindings.
 type Expr :: Type -> Type
-newtype Expr x = Expr {toAST :: Cofree Expression Syntax.TypeSpecifier}
-
--- | A convenience function for lifting an expression into 'Expr'.
-expr_ :: forall x. (Typed x) => Expression (Cofree Expression Syntax.TypeSpecifier) -> Expr x
-expr_ = Expr . \xs -> typeOf @x :< xs
-
--- | We define the expression language using the 'Fix' point of this functor.
--- This allows us to annotate the AST later with other annotations such as
--- types.
-type Expression :: Type -> Type
-data Expression inner
-  = -- | A constant value displayed as an integer. This could be an @int@, but
-    -- it could also be a @uint@ or any other type that can be given as an
-    -- integral constant.
-    IntConstant Integer
-  | -- | A constant vvalue displayed as a floating point number. This should
-    -- either be a @float@ or a @double@.
-    FloatConstant Float
-  | -- | A boolean value of type @boolean@.
-    BoolConstant Bool
-  | -- | Implicit GLSL type conversion.
-    Cast inner
-  | -- | A single field within a vector, or a swizzling mask.
-    FieldSelection String inner
-  | -- | A call to the given function name with the given arguments.
-    FunctionCall String [inner]
-  | -- | Arithmetic sum, which compiles to the GLSL @+@.
-    Add inner inner
-  | -- | Logical AND operation, which compiles to the GLSL @&&@.
-    And inner inner
-  | -- | Logical OR operation, which compiles to the GLSL @&&@.
-    Or inner inner
-  | -- | Boolean selection, which is represented in GLSL with @?@ and @:@. Maps
-    -- exactly to Haskell's @ifThenElse@ construction.
-    Selection inner inner inner
-  deriving stock (Eq, Ord, Functor, Show)
+data Expr x where
+  -- | An integer constant. We can 'Cast' this to @uint@, @float@, or @double@,
+  -- which means we can use 'Shader.Expression.fromInteger' to produce any of
+  -- these types.
+  IntConstant :: Integer -> Expr GLint
+  -- | A floating point constant. We can 'Cast' this to a @double@, so either
+  -- type can be produced using 'Shader.Expression.fromRational'.
+  FloatConstant :: Float -> Expr GLfloat
+  -- | A boolean constant. 'GLboolean' exists in memory as a 'Data.Word.Word8',
+  -- whose @1@ and @0@ values represent 'True' and 'False' respectively.
+  BoolConstant :: Bool -> Expr GLboolean
+  -- | An implicit conversion from one type to another according to the GLSL
+  -- implicit conversion rules.
+  Cast :: (Typed y) => Expr x -> Expr y
+  -- | Use a swizzle mask to select one or more fields from a GLSL vector.
+  FieldSelection :: (Typed y) => String -> Expr x -> Expr y
+  -- | Call a GLSL function with the given arguments.
+  FunctionCall :: (Typed t) => String -> [Some Expr] -> Expr t
+  -- | Add together two GLSL scalars or vectors.
+  Add :: (Typed z) => Expr x -> Expr y -> Expr z
+  -- | Compute the logical conjunction of two GLSL boolean values.
+  And :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
+  -- | Compute the logical disjunction of two GLSL boolean values.
+  Or :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
+  -- | Select one of two values based on a GLSL boolean value.
+  Selection :: (Typed x) => Expr GLboolean -> Expr x -> Expr x -> Expr x
 
 instance (R1 v, Typed e) => HasField "x" (Expr (v e)) (Expr e) where
-  getField = expr_ . FieldSelection "x" . toAST
+  getField = FieldSelection "x"
 
 instance (R2 v, Typed e) => HasField "y" (Expr (v e)) (Expr e) where
-  getField = expr_ . FieldSelection "y" . toAST
+  getField = FieldSelection "y"
 
 instance (R3 v, Typed e) => HasField "z" (Expr (v e)) (Expr e) where
-  getField = expr_ . FieldSelection "z" . toAST
+  getField = FieldSelection "z"
 
 instance (R4 v, Typed e) => HasField "w" (Expr (v e)) (Expr e) where
-  getField = expr_ . FieldSelection "w" . toAST
+  getField = FieldSelection "w"
 
 -- | Convert a Haskell expression into a GLSL abstract syntax tree. This
 -- performs no type-checking and is extremely naïve, so optimisations and AST
 -- passes should be done before this call.
 toGLSL :: Expr x -> Syntax.Expr
-toGLSL = go . toAST
-  where
-    go :: Cofree Expression Syntax.TypeSpecifier -> Syntax.Expr
-    go = cata \(_ CofreeF.:< expr) -> case expr of
-      BoolConstant x -> Syntax.BoolConstant x
-      FloatConstant x -> Syntax.FloatConstant x
-      IntConstant x -> Syntax.IntConstant Syntax.Decimal x
-      Cast x -> x
-      Add x y -> Syntax.Add x y
-      And x y -> Syntax.And x y
-      Or x y -> Syntax.Or x y
-      FieldSelection s xs -> Syntax.FieldSelection xs s
-      FunctionCall f xs -> Syntax.FunctionCall (Syntax.FuncId f) (Syntax.Params xs)
-      Selection p x y -> Syntax.Selection p x y
+toGLSL = \case
+  IntConstant x -> Syntax.IntConstant Syntax.Decimal x
+  FloatConstant x -> Syntax.FloatConstant x
+  BoolConstant x -> Syntax.BoolConstant x
+  Cast x -> toGLSL x
+  Add x y -> Syntax.Add (toGLSL x) (toGLSL y)
+  And x y -> Syntax.And (toGLSL x) (toGLSL y)
+  Or x y -> Syntax.Or (toGLSL x) (toGLSL y)
+  FieldSelection s x -> Syntax.FieldSelection (toGLSL x) s
+  FunctionCall f x -> Syntax.FunctionCall (Syntax.FuncId f) do
+    Syntax.Params (map (Some.foldSome toGLSL) x)
+  Selection p x y -> Syntax.Selection (toGLSL p) (toGLSL x) (toGLSL y)

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -1,31 +1,30 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Boolean logic for GLSL.
 module Shader.Expression.Logic where
 
 import Graphics.Rendering.OpenGL (GLboolean)
-import Shader.Expression.Core (Expr (toAST), Expression (And, BoolConstant, Or, Selection), expr_)
+import Shader.Expression.Core (Expr (And, BoolConstant, Or, Selection))
 import Shader.Expression.Type (Typed)
 
 -- | Boolean 'True'.
 true :: Expr GLboolean
-true = expr_ (BoolConstant True)
+true = BoolConstant True
 
 -- | Boolean 'False'.
 false :: Expr GLboolean
-false = expr_ (BoolConstant False)
+false = BoolConstant False
 
 -- | Boolean conjunction (@AND@).
 (&&) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(&&) (toAST -> x) (toAST -> y) = expr_ (And x y)
+(&&) = And
 
 -- | Boolean disjunction (@OR@).
 (||) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(||) (toAST -> x) (toAST -> y) = expr_ (Or x y)
+(||) = Or
 
 -- | AST "selection". When @RebindableSyntax@ is enabled, regular
 -- @if@/@then@/@else@ syntax can compile to this function.
 ifThenElse :: (Typed x) => Expr GLboolean -> Expr x -> Expr x -> Expr x
-ifThenElse (toAST -> p) (toAST -> x) (toAST -> y) = expr_ (Selection p x y)
+ifThenElse = Selection

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -1,46 +1,46 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
+import Data.Some (Some (Some))
 import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (toAST), Expression (FunctionCall), expr_)
+import Shader.Expression.Core (Expr (FunctionCall))
 
 -- | Construct a @'V2' 'GLboolean'@ from 'GLboolean' components.
 bvec2 :: Expr GLboolean -> Expr GLboolean -> Expr (V2 GLboolean)
-bvec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "bvec2" [x, y])
+bvec2 x y = FunctionCall "bvec2" [Some x, Some y]
 
 -- | Construct a @'V3' 'GLboolean'@ from 'GLboolean' components.
 bvec3 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V3 GLboolean)
-bvec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "bvec3" [x, y, z])
+bvec3 x y z = FunctionCall "bvec3" [Some x, Some y, Some z]
 
 -- | Construct a @'V4' 'GLboolean'@ from 'GLboolean' components.
 bvec4 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V4 GLboolean)
-bvec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "bvec4" [x, y, z, w])
+bvec4 x y z w = FunctionCall "bvec4" [Some x, Some y, Some z, Some w]
 
 -- | Construct a @'V2' 'GLint'@ from 'GLint' components.
 ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)
-ivec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "ivec2" [x, y])
+ivec2 x y = FunctionCall "ivec2" [Some x, Some y]
 
 -- | Construct a @'V3' 'GLint'@ from 'GLint' components.
 ivec3 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr (V3 GLint)
-ivec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "ivec3" [x, y, z])
+ivec3 x y z = FunctionCall "ivec3" [Some x, Some y, Some z]
 
 -- | Construct a @'V4' 'GLint'@ from 'GLint' components.
 ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
-ivec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "ivec4" [x, y, z, w])
+ivec4 x y z w = FunctionCall "ivec4" [Some x, Some y, Some z, Some w]
 
 -- | Construct a @'V2' 'GLfloat'@ from 'GLfloat' components.
 vec2 :: Expr GLfloat -> Expr GLfloat -> Expr (V2 GLfloat)
-vec2 (toAST -> x) (toAST -> y) = expr_ (FunctionCall "vec2" [x, y])
+vec2 x y = FunctionCall "vec2" [Some x, Some y]
 
 -- | Construct a @'V3' 'GLfloat'@ from 'GLfloat' components.
 vec3 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V3 GLfloat)
-vec3 (toAST -> x) (toAST -> y) (toAST -> z) = expr_ (FunctionCall "vec3" [x, y, z])
+vec3 x y z = FunctionCall "vec3" [Some x, Some y, Some z]
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
-vec4 (toAST -> x) (toAST -> y) (toAST -> z) (toAST -> w) = expr_ (FunctionCall "vec4" [x, y, z, w])
+vec4 x y z w = FunctionCall "vec4" [Some x, Some y, Some z, Some w]


### PR DESCRIPTION
Once we involve cofrees and recursion schemes, it's sensible to ask whether we're making a mess for too small a gain. This PR replaces all that with a plain GADT and carries the type witnesses as constraints.