### PR TITLE
Generalise `renderExpr`, tidy up the tests

### DIFF
--- a/shaders/tests/Shader/Expression/AdditionSpec.hs
+++ b/shaders/tests/Shader/Expression/AdditionSpec.hs
@@ -1,129 +1,104 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Shader.Expression.AdditionSpec where
 
 import Control.Monad.IO.Class (liftIO)
 import Graphics.Rendering.OpenGL (GLfloat)
-import Hedgehog (forAll)
+import Hedgehog (Gen, forAll)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.Roughly (isRoughly)
-import Linear (V2, V3, V4 (V4))
-import Shader.Expression (Expr, lift, vec2, vec3, vec4, (+))
+import Linear (V1 (V1), V2 (V2), V3 (V3), V4 (V4))
+import Shader.Expression (lift, vec2, vec3, vec4, (+))
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding ((+))
 import Prelude qualified
 
+genZeroToHalf :: Gen GLfloat
+genZeroToHalf = Gen.float (Range.linearFrac 0 0.5)
+
 spec :: SpecWith Renderer
 spec = do
   it "GLfloat + GLfloat = GLfloat" \renderer -> hedgehog do
-    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
 
-    output <- liftIO $ renderExpr renderer do
-      vec4 (lift x1 + lift x2) (lift y) (lift z) (lift 1)
-
-    V4 (x1 Prelude.+ x2) y z 1 `isRoughly` output
+    output <- liftIO $ renderExpr renderer (lift x + lift y)
+    V1 (x Prelude.+ y) `isRoughly` V1 output
 
   it "V2 GLfloat + GLfloat = V2 GLfloat" \renderer -> hedgehog do
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
+    r <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLfloat)
-          partial = vec2 (lift x) (lift y) + lift r
+      vec2 (lift x) (lift y) + lift r
 
-      vec4 partial.x partial.y (lift z) (lift 1)
-
-    V4 (x Prelude.+ r) (y Prelude.+ r) z 1 `isRoughly` output
+    V2 (x Prelude.+ r) (y Prelude.+ r) `isRoughly` output
 
   it "GLfloat + V2 GLfloat = V2 GLfloat" \renderer -> hedgehog do
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    r <- forAll genZeroToHalf
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLfloat)
-          partial = lift r + vec2 (lift x) (lift y)
+      lift r + vec2 (lift x) (lift y)
 
-      vec4 partial.x partial.y (lift z) (lift 1)
-
-    V4 (x Prelude.+ r) (y Prelude.+ r) z 1 `isRoughly` output
+    V2 (x Prelude.+ r) (y Prelude.+ r) `isRoughly` output
 
   it "V2 GLfloat + V2 GLfloat = V2 GLfloat" \renderer -> hedgehog do
-    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    a <- forAll genZeroToHalf
+    b <- forAll genZeroToHalf
+    c <- forAll genZeroToHalf
+    d <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLfloat)
-          partial = vec2 (lift x1) (lift y1) + vec2 (lift x2) (lift y2)
+      vec2 (lift a) (lift b) + vec2 (lift c) (lift d)
 
-      vec4 partial.x partial.y (lift z) (lift 1)
-
-    V4 (x1 Prelude.+ x2) (y1 Prelude.+ y2) z 1 `isRoughly` output
+    V2 (a Prelude.+ c) (b Prelude.+ d) `isRoughly` output
 
   it "V3 GLfloat + GLfloat = V3 GLfloat" \renderer -> hedgehog do
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
+    z <- forAll genZeroToHalf
+    r <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLfloat)
-          partial = vec3 (lift x) (lift y) (lift z) + lift r
+      vec3 (lift x) (lift y) (lift z) + lift r
 
-      vec4 partial.x partial.y partial.z (lift 1)
-
-    V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
+    V3 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) `isRoughly` output
 
   it "GLfloat + V3 GLfloat = V3 GLfloat" \renderer -> hedgehog do
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    r <- forAll genZeroToHalf
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
+    z <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLfloat)
-          partial = lift r + vec3 (lift x) (lift y) (lift z)
+      lift r + vec3 (lift x) (lift y) (lift z)
 
-      vec4 partial.x partial.y partial.z (lift 1)
-
-    V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
+    V3 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) `isRoughly` output
 
   it "V3 GLfloat + V3 GLfloat = V3 GLfloat" \renderer -> hedgehog do
-    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    a <- forAll genZeroToHalf
+    b <- forAll genZeroToHalf
+    c <- forAll genZeroToHalf
+    d <- forAll genZeroToHalf
+    e <- forAll genZeroToHalf
+    f <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLfloat)
-          partial =
-            vec3 (lift x1) (lift y1) (lift z1)
-              + vec3 (lift x2) (lift y2) (lift z2)
+      vec3 (lift a) (lift b) (lift c) + vec3 (lift d) (lift e) (lift f)
 
-      vec4 partial.x partial.y partial.z (lift 1)
-
-    V4 (x1 Prelude.+ x2) (y1 Prelude.+ y2) (z1 Prelude.+ z2) 1 `isRoughly` output
+    V3 (a Prelude.+ d) (b Prelude.+ e) (c Prelude.+ f) `isRoughly` output
 
   it "V4 GLfloat + GLfloat = V4 GLfloat" \renderer -> hedgehog do
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
+    z <- forAll genZeroToHalf
+    r <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
       vec4 (lift x) (lift y) (lift z) (lift (1 - r)) + lift r
@@ -131,10 +106,10 @@ spec = do
     V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
 
   it "GLfloat + V4 GLfloat = V4 GLfloat" \renderer -> hedgehog do
-    r <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    r <- forAll genZeroToHalf
+    x <- forAll genZeroToHalf
+    y <- forAll genZeroToHalf
+    z <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
       lift r + vec4 (lift x) (lift y) (lift z) (lift (1 - r))
@@ -142,15 +117,15 @@ spec = do
     V4 (x Prelude.+ r) (y Prelude.+ r) (z Prelude.+ r) 1 `isRoughly` output
 
   it "V4 GLfloat + V4 GLfloat = V4 GLfloat" \renderer -> hedgehog do
-    x1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    x2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    y2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z1 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
-    z2 <- forAll $ Gen.float (Range.linearFrac 0 0.5)
+    a <- forAll genZeroToHalf
+    b <- forAll genZeroToHalf
+    c <- forAll genZeroToHalf
+    d <- forAll genZeroToHalf
+    e <- forAll genZeroToHalf
+    f <- forAll genZeroToHalf
 
     output <- liftIO $ renderExpr renderer do
-      vec4 (lift x1) (lift y1) (lift z1) (lift 0.5)
-        + vec4 (lift x2) (lift y2) (lift z2) (lift 0.5)
+      vec4 (lift a) (lift b) (lift c) (lift 0.5)
+        + vec4 (lift d) (lift e) (lift f) (lift 0.5)
 
-    V4 (x1 Prelude.+ x2) (y1 Prelude.+ y2) (z1 Prelude.+ z2) 1 `isRoughly` output
+    V4 (a Prelude.+ d) (b Prelude.+ e) (c Prelude.+ f) 1 `isRoughly` output

--- a/shaders/tests/Shader/Expression/CastSpec.hs
+++ b/shaders/tests/Shader/Expression/CastSpec.hs
@@ -6,11 +6,10 @@ import Control.Monad.IO.Class (liftIO)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Hedgehog (forAll)
 import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.Roughly (isRoughly)
-import Linear (V4 (V4))
-import Shader.Expression (cast, ivec4, lift, vec4)
+import Linear (V1 (V1), V4 (V4))
+import Shader.Expression (cast, ivec4, lift)
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 
@@ -18,21 +17,18 @@ spec :: SpecWith Renderer
 spec = do
   it "int -> float" \renderer -> hedgehog do
     x <- forAll $ Gen.element [0, 1]
-    y <- forAll $ Gen.float (Range.linearFrac 0 1)
-    z <- forAll $ Gen.float (Range.linearFrac 0 1)
 
     output <- liftIO $ renderExpr renderer do
-      let x' = cast @GLint @GLfloat (lift x)
-      vec4 x' (lift y) (lift z) (lift 1)
+      cast @GLint @GLfloat (lift x)
 
-    V4 (fromIntegral x) y z 1 `isRoughly` output
+    V1 (fromIntegral x) `isRoughly` V1 output
 
   it "V4 int -> V4 float" \renderer -> hedgehog do
     x <- forAll $ Gen.element [0, 1]
     y <- forAll $ Gen.element [0, 1]
     z <- forAll $ Gen.element [0, 1]
 
-    output <- liftIO $ renderExpr renderer do
+    output <- liftIO $ renderExpr @(V4 GLfloat) renderer do
       cast (ivec4 (lift x) (lift y) (lift z) (lift 1))
 
     fmap fromIntegral (V4 x y z 1) `isRoughly` output

--- a/shaders/tests/Shader/Expression/ConstantsSpec.hs
+++ b/shaders/tests/Shader/Expression/ConstantsSpec.hs
@@ -1,18 +1,16 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Shader.Expression.ConstantsSpec where
 
 import Control.Monad.IO.Class (liftIO)
-import Data.Bool (bool)
-import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
-import Hedgehog (Gen, forAll)
+import Graphics.Rendering.OpenGL (GLboolean, GLint)
+import Hedgehog (Gen, forAll, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.Roughly (isRoughly)
-import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression (Expr, cast, ifThenElse, ivec4, lift, vec4)
+import Linear (V1 (V1), V2 (V2), V3 (V3), V4 (V4))
+import Shader.Expression (lift)
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding (fromInteger, fromRational)
@@ -20,88 +18,60 @@ import Prelude hiding (fromInteger, fromRational)
 genZeroToOne :: Gen Float
 genZeroToOne = Gen.float (Range.linearFrac 0 1)
 
+genBoolean :: Gen GLboolean
+genBoolean = Gen.element [1, 0]
+
 spec :: SpecWith Renderer
 spec = do
-  let bool2gl :: Bool -> GLboolean
-      bool2gl = bool 0 1
-
-      bool2float :: Bool -> Float
-      bool2float = bool 0 1
-
-      enum :: Expr GLboolean -> Expr GLfloat
-      enum p = ifThenElse p (lift 1) (lift 0)
-
   it "lift @GLboolean" \renderer -> hedgehog do
-    x <- forAll Gen.bool
+    x <- forAll genBoolean
 
-    output <- liftIO $ renderExpr renderer do
-      let partial :: Expr GLboolean
-          partial = lift (bool2gl x)
-
-      vec4 (enum partial) (lift 1) (lift 1) (lift 1)
-
-    V4 (bool2float x) 1 1 1 `isRoughly` output
+    output <- liftIO $ renderExpr renderer (lift x)
+    V1 x === V1 output
 
   it "lift @(V2 GLboolean)" \renderer -> hedgehog do
-    x <- forAll Gen.bool
-    y <- forAll Gen.bool
+    x <- forAll genBoolean
+    y <- forAll genBoolean
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLboolean)
-          partial = lift (V2 (bool2gl x) (bool2gl y))
+      lift (V2 x y)
 
-      vec4 (enum partial.x) (enum partial.y) (lift 1) (lift 1)
-
-    V4 (bool2float x) (bool2float y) 1 1 `isRoughly` output
+    V2 x y === output
 
   it "lift @(V3 GLboolean)" \renderer -> hedgehog do
-    x <- forAll Gen.bool
-    y <- forAll Gen.bool
-    z <- forAll Gen.bool
+    x <- forAll genBoolean
+    y <- forAll genBoolean
+    z <- forAll genBoolean
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLboolean)
-          partial = lift (V3 (bool2gl x) (bool2gl y) (bool2gl z))
+      lift (V3 x y z)
 
-      vec4 (enum partial.x) (enum partial.y) (enum partial.z) (lift 1)
-
-    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+    V3 x y z === output
 
   it "lift @(V4 GLboolean)" \renderer -> hedgehog do
-    x <- forAll Gen.bool
-    y <- forAll Gen.bool
-    z <- forAll Gen.bool
+    x <- forAll genBoolean
+    y <- forAll genBoolean
+    z <- forAll genBoolean
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V4 GLboolean)
-          partial = lift (V4 (bool2gl x) (bool2gl y) (bool2gl z) (bool2gl True))
+      lift (V4 x y z 1)
 
-      vec4 (enum partial.x) (enum partial.y) (enum partial.z) (enum partial.w)
-
-    V4 (bool2float x) (bool2float y) (bool2float z) 1 `isRoughly` output
+    V4 x y z 1 === output
 
   it "lift @GLfloat" \renderer -> hedgehog do
     x <- forAll genZeroToOne
-    y <- forAll genZeroToOne
-    z <- forAll genZeroToOne
 
-    output <- liftIO $ renderExpr renderer do
-      vec4 (lift x) (lift y) (lift z) (lift 1)
-
-    V4 x y z 1 `isRoughly` output
+    output <- liftIO $ renderExpr renderer (lift x)
+    V1 x `isRoughly` V1 output
 
   it "lift @(V2 GLfloat)" \renderer -> hedgehog do
     x <- forAll genZeroToOne
     y <- forAll genZeroToOne
-    z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLfloat)
-          partial = lift (V2 x y)
+      lift (V2 x y)
 
-      vec4 partial.x partial.y (lift z) (lift 1)
-
-    V4 x y z 1 `isRoughly` output
+    V2 x y `isRoughly` output
 
   it "lift @(V3 GLfloat)" \renderer -> hedgehog do
     x <- forAll genZeroToOne
@@ -109,66 +79,51 @@ spec = do
     z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLfloat)
-          partial = lift (V3 x y z)
+      lift (V3 x y z)
 
-      vec4 partial.x partial.y partial.z (lift 1)
+    V3 x y z `isRoughly` output
+
+  it "lift @(V4 GLfloat)" \renderer -> hedgehog do
+    x <- forAll genZeroToOne
+    y <- forAll genZeroToOne
+    z <- forAll genZeroToOne
+
+    output <- liftIO $ renderExpr renderer do
+      lift (V4 x y z 1)
 
     V4 x y z 1 `isRoughly` output
 
-  it "lift @(V4 GLfloat)" \renderer -> hedgehog do
-    input <- forAll do
-      x <- genZeroToOne
-      y <- genZeroToOne
-      z <- genZeroToOne
-
-      pure $ V4 @GLfloat x y z 1
-
-    output <- liftIO $ renderExpr renderer (lift input)
-    input `isRoughly` output
-
   it "lift @GLint" \renderer -> hedgehog do
-    x <- forAll $ Gen.element [0, 1]
-    y <- forAll $ Gen.element [0, 1]
-    z <- forAll $ Gen.element [0, 1]
+    x :: GLint <- forAll (Gen.element [0, 1])
 
-    output <- liftIO $ renderExpr renderer do
-      cast (ivec4 (lift x) (lift y) (lift z) (lift 1))
-
-    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+    output <- liftIO $ renderExpr renderer (lift x)
+    V1 x === V1 output
 
   it "lift @(V2 GLint)" \renderer -> hedgehog do
-    x <- forAll $ Gen.element [0, 1]
-    y <- forAll $ Gen.element [0, 1]
-    z <- forAll $ Gen.element [0, 1]
+    x :: GLint <- forAll (Gen.element [0, 1])
+    y :: GLint <- forAll (Gen.element [0, 1])
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V2 GLint)
-          partial = lift (V2 x y)
+      lift (V2 x y)
 
-      cast (ivec4 partial.x partial.y (lift z) (lift 1))
-
-    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+    V2 x y === output
 
   it "lift @(V3 GLint)" \renderer -> hedgehog do
-    x <- forAll $ Gen.element [0, 1]
-    y <- forAll $ Gen.element [0, 1]
-    z <- forAll $ Gen.element [0, 1]
+    x :: GLint <- forAll (Gen.element [0, 1])
+    y :: GLint <- forAll (Gen.element [0, 1])
+    z :: GLint <- forAll (Gen.element [0, 1])
 
     output <- liftIO $ renderExpr renderer do
-      let partial :: Expr (V3 GLint)
-          partial = lift (V3 x y z)
+      lift (V3 x y z)
 
-      cast (ivec4 partial.x partial.y partial.z (lift 1))
-
-    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+    V3 x y z === output
 
   it "lift @(V4 GLint)" \renderer -> hedgehog do
-    x <- forAll $ Gen.element [0, 1]
-    y <- forAll $ Gen.element [0, 1]
-    z <- forAll $ Gen.element [0, 1]
+    x :: GLint <- forAll (Gen.element [0, 1])
+    y :: GLint <- forAll (Gen.element [0, 1])
+    z :: GLint <- forAll (Gen.element [0, 1])
 
     output <- liftIO $ renderExpr renderer do
-      cast @(V4 GLint) (lift (V4 x y z 1))
+      lift (V4 x y z 1)
 
-    fmap fromIntegral (V4 x y z 1) `isRoughly` output
+    V4 x y z 1 === output

--- a/shaders/tests/Shader/Expression/LogicSpec.hs
+++ b/shaders/tests/Shader/Expression/LogicSpec.hs
@@ -1,79 +1,48 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RebindableSyntax #-}
 
 module Shader.Expression.LogicSpec where
 
 import Control.Monad.IO.Class (liftIO)
-import Data.Bool (bool)
-import GHC.Records (getField)
-import Graphics.Rendering.OpenGL (GLboolean, GLfloat)
-import Hedgehog (forAll)
+import Graphics.Rendering.OpenGL (GLboolean)
+import Hedgehog (Gen, forAll)
 import Hedgehog.Gen qualified as Gen
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.RendererSpec (genZeroToOne)
-import Helper.Roughly (isRoughly, shouldRoughlyBe)
-import Linear (V3 (V3), V4 (V4))
-import Shader.Expression (Expr, false, ifThenElse, lift, true, vec4, (&&), (||))
-import Test.Hspec (SpecWith, it)
+import Helper.Roughly (isRoughly)
+import Linear (V1 (V1), V4 (V4))
+import Shader.Expression (Expr, bvec4, false, ifThenElse, lift, true, (&&), (||))
+import Test.Hspec (SpecWith, it, shouldBe)
 import Test.Hspec.Hedgehog (hedgehog)
 import Prelude hiding ((&&), (||))
+
+genBoolean :: Gen GLboolean
+genBoolean = Gen.element [1, 0]
 
 spec :: SpecWith Renderer
 spec = do
   it "selection" \renderer -> hedgehog do
-    p <- forAll Gen.bool
-
-    a <- forAll genZeroToOne
-    b <- forAll genZeroToOne
-    c <- forAll genZeroToOne
+    p <- forAll genBoolean
 
     x <- forAll genZeroToOne
     y <- forAll genZeroToOne
-    z <- forAll genZeroToOne
 
     output <- liftIO $ renderExpr renderer do
-      let check :: Expr GLboolean
-          check = bool false true p
+      if lift p then lift x else lift y
 
-          partial :: Expr (V3 GLfloat)
-          partial =
-            if check
-              then lift (V3 a b c)
-              else lift (V3 x y z)
+    V1 output `isRoughly` case p of
+      1 -> V1 x
+      _ -> V1 y
 
-      vec4 partial.x partial.y partial.z (lift 1)
-
-    output `isRoughly` bool (V4 x y z 1) (V4 a b c 1) p
+  let test :: (Expr GLboolean -> Expr GLboolean -> Expr GLboolean) -> Expr (V4 GLboolean)
+      test f = bvec4 (g false false) (g false true) (g true false) (g true true)
+        where
+          g x y = if f x y then lift 1 else lift 0
 
   it "conjunction" \renderer -> do
-    let x :: Expr GLfloat
-        x = if false && false then lift 1 else lift 0
-
-        y :: Expr GLfloat
-        y = if false && true then lift 1 else lift 0
-
-        z :: Expr GLfloat
-        z = if true && false then lift 1 else lift 0
-
-        w :: Expr GLfloat
-        w = if true && true then lift 1 else lift 0
-
-    output <- liftIO $ renderExpr renderer (vec4 x y z w)
-    V4 0 0 0 1 `shouldRoughlyBe` output
+    output <- liftIO $ renderExpr renderer (test (&&))
+    V4 0 0 0 1 `shouldBe` output
 
   it "disjunction" \renderer -> do
-    let x :: Expr GLfloat
-        x = if false || false then lift 1 else lift 0
-
-        y :: Expr GLfloat
-        y = if false || true then lift 1 else lift 0
-
-        z :: Expr GLfloat
-        z = if true || false then lift 1 else lift 0
-
-        w :: Expr GLfloat
-        w = if true || true then lift 1 else lift 0
-
-    output <- liftIO $ renderExpr renderer (vec4 x y z w)
-    V4 0 1 1 1 `shouldRoughlyBe` output
+    output <- liftIO $ renderExpr renderer (test (||))
+    V4 0 1 1 1 `shouldBe` output


### PR DESCRIPTION
The tests are a bit cumbersome at the moment because, in order to check the result of a GLSL computation, we have to express that result as a `vec4`. We do this so that we can perform the computation in a fragment shader, then render a pixel's colour to the answer. This pixel's colour can then be read to "extract" a value from the shader.

However, this means that every test involves generating a value, performing a computation, converting it to a `vec4`, then converting a `V4 GLfloat` into whatever we want. It's a bit of a pain.

This PR extracts that roundtripping logic into a new class, `Roundtrip`, and simplifies all the tests by removing the conversions in both directions. They're certainly easier to read.