### PR TITLE
Implement more "implicit" conversions

### DIFF
--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -4,7 +4,7 @@ module Shader.Expression.Cast where
 
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
-import Linear (V4)
+import Linear (V2, V3, V4)
 import Shader.Expression.Core (Expr (Cast))
 import Shader.Expression.Type (Typed)
 
@@ -22,4 +22,8 @@ class Cast x y
 
 instance Cast GLint GLfloat
 
-instance (Cast x y) => Cast (V4 x) (V4 y)
+instance Cast (V2 GLint) (V2 GLfloat)
+
+instance Cast (V3 GLint) (V3 GLfloat)
+
+instance Cast (V4 GLint) (V4 GLfloat)

--- a/shaders/tests/Shader/Expression/CastSpec.hs
+++ b/shaders/tests/Shader/Expression/CastSpec.hs
@@ -8,8 +8,8 @@ import Hedgehog (forAll)
 import Hedgehog.Gen qualified as Gen
 import Helper.Renderer (Renderer, renderExpr)
 import Helper.Roughly (isRoughly)
-import Linear (V1 (V1), V4 (V4))
-import Shader.Expression (cast, ivec4, lift)
+import Linear (V1 (V1), V2 (V2), V3 (V3), V4 (V4))
+import Shader.Expression (cast, ivec2, ivec3, ivec4, lift)
 import Test.Hspec (SpecWith, it)
 import Test.Hspec.Hedgehog (hedgehog)
 
@@ -22,6 +22,25 @@ spec = do
       cast @GLint @GLfloat (lift x)
 
     V1 (fromIntegral x) `isRoughly` V1 output
+
+  it "V2 int -> V2 float" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+
+    output <- liftIO $ renderExpr @(V2 GLfloat) renderer do
+      cast (ivec2 (lift x) (lift y))
+
+    fmap fromIntegral (V2 x y) `isRoughly` output
+
+  it "V3 int -> V3 float" \renderer -> hedgehog do
+    x <- forAll $ Gen.element [0, 1]
+    y <- forAll $ Gen.element [0, 1]
+    z <- forAll $ Gen.element [0, 1]
+
+    output <- liftIO $ renderExpr @(V3 GLfloat) renderer do
+      cast (ivec3 (lift x) (lift y) (lift z))
+
+    fmap fromIntegral (V3 x y z) `isRoughly` output
 
   it "V4 int -> V4 float" \renderer -> hedgehog do
     x <- forAll $ Gen.element [0, 1]


### PR DESCRIPTION
We can cast any vector of integers to a vector of floats.