### PR TITLE
Revert to `Cofree`

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -26,9 +26,11 @@ library
     Shader.Expression.Vector
   build-depends:
     , base
+    , free
     , language-glsl
     , linear
     , OpenGL
+    , recursion-schemes
     , some
   ghc-options: -Wall -Wextra
   hs-source-dirs: source
@@ -43,6 +45,7 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
+    , free
     , hedgehog
     , hspec
     , hspec-hedgehog
@@ -50,6 +53,7 @@ test-suite shaders-test
     , linear
     , OpenGL
     , prettyclass
+    , recursion-schemes
     , sdl2
     , shaders
     , some

--- a/shaders/source/Shader/Expression/Addition.hs
+++ b/shaders/source/Shader/Expression/Addition.hs
@@ -8,12 +8,12 @@ module Shader.Expression.Addition where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat)
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (Add))
+import Shader.Expression.Core (Expr (Expr), ExprF (Add), unsafeLift)
 import Shader.Expression.Type (Typed)
 
 -- | Add together two GLSL expressions.
 (+) :: (Add x y z, Typed z) => Expr x -> Expr y -> Expr z
-(+) = Add
+(+) (Expr x) (Expr y) = unsafeLift (Add x y)
 
 -- | In GLSL, we can add scalars to vectors and matrices to perform
 -- component-wise changes. Because of this, the output type is computed as a

--- a/shaders/source/Shader/Expression/Cast.hs
+++ b/shaders/source/Shader/Expression/Cast.hs
@@ -5,7 +5,7 @@ module Shader.Expression.Cast where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLfloat, GLint)
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (Cast))
+import Shader.Expression.Core (Expr (unExpr), ExprF (Cast), unsafeLift)
 import Shader.Expression.Type (Typed)
 
 -- | GLSL supports implicit conversions: if a @uint@ is expected and you give
@@ -14,7 +14,7 @@ import Shader.Expression.Type (Typed)
 -- This should be zero cost: in theory, @cast x@ should have the same GLSL
 -- representation as @x@.
 cast :: (Cast x y, Typed y) => Expr x -> Expr y
-cast = Cast
+cast = unsafeLift . Cast . unExpr
 
 -- | Types that can be implicitly converted into other types.
 type Cast :: Type -> Type -> Constraint

--- a/shaders/source/Shader/Expression/Constants.hs
+++ b/shaders/source/Shader/Expression/Constants.hs
@@ -12,7 +12,7 @@ where
 import Data.Kind (Constraint, Type)
 import Graphics.Rendering.OpenGL (GLboolean, GLdouble, GLfloat, GLint, GLuint)
 import Linear (V2 (V2), V3 (V3), V4 (V4))
-import Shader.Expression.Core (Expr (BoolConstant, Cast, FloatConstant, IntConstant))
+import Shader.Expression.Core (Expr (unExpr), ExprF (BoolConstant, Cast, FloatConstant, IntConstant), unsafeLift)
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)
 import Prelude hiding (fromInteger, fromRational)
 import Prelude qualified
@@ -26,7 +26,7 @@ class Lift x where
 instance Lift GLboolean where
   -- As defined in the @OpenGLRaw@ package.
   lift =
-    BoolConstant . \case
+    unsafeLift . BoolConstant . \case
       1 -> True
       _ -> False
 
@@ -40,10 +40,10 @@ instance Lift (V4 GLboolean) where
   lift (V4 x y z w) = bvec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLdouble where
-  lift = Cast . FloatConstant . realToFrac
+  lift = unsafeLift . Cast . unExpr . lift @GLfloat . realToFrac
 
 instance Lift GLfloat where
-  lift = FloatConstant
+  lift = unsafeLift . FloatConstant
 
 instance Lift (V2 GLfloat) where
   lift (V2 x y) = vec2 (lift x) (lift y)
@@ -55,7 +55,7 @@ instance Lift (V4 GLfloat) where
   lift (V4 x y z w) = vec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLint where
-  lift = IntConstant . fromIntegral
+  lift = unsafeLift . IntConstant . fromIntegral
 
 instance Lift (V2 GLint) where
   lift (V2 x y) = ivec2 (lift x) (lift y)
@@ -67,7 +67,7 @@ instance Lift (V4 GLint) where
   lift (V4 x y z w) = ivec4 (lift x) (lift y) (lift z) (lift w)
 
 instance Lift GLuint where
-  lift = Cast . IntConstant . fromIntegral
+  lift = unsafeLift . Cast . unExpr . lift @GLint . fromIntegral
 
 -- | @RebindableSyntax@ function for integer literals.
 fromInteger :: (Lift x, Num x) => Integer -> Expr x

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -1,83 +1,81 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Typed syntactic sugar on top of @language-glsl@.
 module Shader.Expression.Core
   ( Expr (..),
     toGLSL,
+    ExprF (..),
+    unsafeLift,
   )
 where
 
+import Control.Comonad.Cofree (Cofree ((:<)))
+import Control.Comonad.Trans.Cofree qualified as C
+import Data.Functor.Foldable (cata)
 import Data.Kind (Type)
-import Data.Some (Some)
-import Data.Some qualified as Some
 import GHC.Records (HasField (getField))
-import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (R1, R2, R3, R4)
-import Shader.Expression.Type (Typed)
+import Shader.Expression.Type (Typed (typeOf))
 
 -- | An expression is a GLSL value that has a type. We keep track of the type
 -- of the expression and all its subexpressions in case we want to factor them
 -- out as intermediate bindings.
 type Expr :: Type -> Type
-data Expr x where
-  -- | An integer constant. We can 'Cast' this to @uint@, @float@, or @double@,
-  -- which means we can use 'Shader.Expression.fromInteger' to produce any of
-  -- these types.
-  IntConstant :: Integer -> Expr GLint
-  -- | A floating point constant. We can 'Cast' this to a @double@, so either
-  -- type can be produced using 'Shader.Expression.fromRational'.
-  FloatConstant :: Float -> Expr GLfloat
-  -- | A boolean constant. 'GLboolean' exists in memory as a 'Data.Word.Word8',
-  -- whose @1@ and @0@ values represent 'True' and 'False' respectively.
-  BoolConstant :: Bool -> Expr GLboolean
-  -- | An implicit conversion from one type to another according to the GLSL
-  -- implicit conversion rules.
-  Cast :: (Typed y) => Expr x -> Expr y
-  -- | Use a swizzle mask to select one or more fields from a GLSL vector.
-  FieldSelection :: (Typed y) => String -> Expr x -> Expr y
-  -- | Call a GLSL function with the given arguments.
-  FunctionCall :: (Typed t) => String -> [Some Expr] -> Expr t
-  -- | Add together two GLSL scalars or vectors.
-  Add :: (Typed z) => Expr x -> Expr y -> Expr z
-  -- | Compute the logical conjunction of two GLSL boolean values.
-  And :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-  -- | Compute the logical disjunction of two GLSL boolean values.
-  Or :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-  -- | Select one of two values based on a GLSL boolean value.
-  Selection :: (Typed x) => Expr GLboolean -> Expr x -> Expr x -> Expr x
+newtype Expr x = Expr {unExpr :: Cofree ExprF Syntax.TypeSpecifier}
+
+-- | The inner data type for 'Expr'. These constructors should map in very
+-- straightforward ways to 'Syntax.Expr'. We express this as a separate functor
+-- so that we can both fold it /and/ reuse it for generating intermediate
+-- binds.
+type ExprF :: Type -> Type
+data ExprF expr
+  = IntConstant Integer
+  | FloatConstant Float
+  | BoolConstant Bool
+  | Cast expr
+  | FieldSelection String expr
+  | FunctionCall String [expr]
+  | Add expr expr
+  | And expr expr
+  | Or expr expr
+  | Selection expr expr expr
+  deriving stock (Functor)
+
+-- | Lift a chunk of AST into an 'Expr' with the given type. This is a very
+-- unsafe function as there's no guarantees about type correctness, and is only
+-- here as a convenience function for internnal definitions.
+unsafeLift :: forall x. (Typed x) => ExprF (Cofree ExprF Syntax.TypeSpecifier) -> Expr x
+unsafeLift xs = Expr (typeOf @x :< xs)
 
 instance (R1 v, Typed e) => HasField "x" (Expr (v e)) (Expr e) where
-  getField = FieldSelection "x"
+  getField (Expr xs) = unsafeLift (FieldSelection "x" xs)
 
 instance (R2 v, Typed e) => HasField "y" (Expr (v e)) (Expr e) where
-  getField = FieldSelection "y"
+  getField (Expr xs) = unsafeLift (FieldSelection "y" xs)
 
 instance (R3 v, Typed e) => HasField "z" (Expr (v e)) (Expr e) where
-  getField = FieldSelection "z"
+  getField (Expr xs) = unsafeLift (FieldSelection "z" xs)
 
 instance (R4 v, Typed e) => HasField "w" (Expr (v e)) (Expr e) where
-  getField = FieldSelection "w"
+  getField (Expr xs) = unsafeLift (FieldSelection "w" xs)
 
 -- | Convert a Haskell expression into a GLSL abstract syntax tree. This
 -- performs no type-checking and is extremely naïve, so optimisations and AST
 -- passes should be done before this call.
 toGLSL :: Expr x -> Syntax.Expr
-toGLSL = \case
-  IntConstant x -> Syntax.IntConstant Syntax.Decimal x
-  FloatConstant x -> Syntax.FloatConstant x
-  BoolConstant x -> Syntax.BoolConstant x
-  Cast x -> toGLSL x
-  Add x y -> Syntax.Add (toGLSL x) (toGLSL y)
-  And x y -> Syntax.And (toGLSL x) (toGLSL y)
-  Or x y -> Syntax.Or (toGLSL x) (toGLSL y)
-  FieldSelection s x -> Syntax.FieldSelection (toGLSL x) s
-  FunctionCall f x -> Syntax.FunctionCall (Syntax.FuncId f) do
-    Syntax.Params (map (Some.foldSome toGLSL) x)
-  Selection p x y -> Syntax.Selection (toGLSL p) (toGLSL x) (toGLSL y)
+toGLSL = cata go . unExpr
+  where
+    go exprF = case C.tailF exprF of
+      IntConstant x -> Syntax.IntConstant Syntax.Decimal x
+      FloatConstant x -> Syntax.FloatConstant x
+      BoolConstant x -> Syntax.BoolConstant x
+      Cast x -> x
+      Add x y -> Syntax.Add x y
+      And x y -> Syntax.And x y
+      Or x y -> Syntax.Or x y
+      FieldSelection s x -> Syntax.FieldSelection x s
+      FunctionCall f xs -> Syntax.FunctionCall (Syntax.FuncId f) (Syntax.Params xs)
+      Selection p x y -> Syntax.Selection p x y

--- a/shaders/source/Shader/Expression/Logic.hs
+++ b/shaders/source/Shader/Expression/Logic.hs
@@ -5,26 +5,26 @@
 module Shader.Expression.Logic where
 
 import Graphics.Rendering.OpenGL (GLboolean)
-import Shader.Expression.Core (Expr (And, BoolConstant, Or, Selection))
+import Shader.Expression.Core (Expr (Expr), ExprF (And, BoolConstant, Or, Selection), unsafeLift)
 import Shader.Expression.Type (Typed)
 
 -- | Boolean 'True'.
 true :: Expr GLboolean
-true = BoolConstant True
+true = unsafeLift (BoolConstant True)
 
 -- | Boolean 'False'.
 false :: Expr GLboolean
-false = BoolConstant False
+false = unsafeLift (BoolConstant False)
 
 -- | Boolean conjunction (@AND@).
 (&&) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(&&) = And
+(&&) (Expr x) (Expr y) = unsafeLift (And x y)
 
 -- | Boolean disjunction (@OR@).
 (||) :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean
-(||) = Or
+(||) (Expr x) (Expr y) = unsafeLift (Or x y)
 
 -- | AST "selection". When @RebindableSyntax@ is enabled, regular
 -- @if@/@then@/@else@ syntax can compile to this function.
 ifThenElse :: (Typed x) => Expr GLboolean -> Expr x -> Expr x -> Expr x
-ifThenElse = Selection
+ifThenElse (Expr p) (Expr x) (Expr y) = unsafeLift (Selection p x y)

--- a/shaders/source/Shader/Expression/Vector.hs
+++ b/shaders/source/Shader/Expression/Vector.hs
@@ -4,43 +4,42 @@
 -- Functions for constructing GLSL vectors.
 module Shader.Expression.Vector where
 
-import Data.Some (Some (Some))
 import Graphics.Rendering.OpenGL (GLboolean, GLfloat, GLint)
 import Linear (V2, V3, V4)
-import Shader.Expression.Core (Expr (FunctionCall))
+import Shader.Expression.Core (Expr (Expr), ExprF (FunctionCall), unsafeLift)
 
 -- | Construct a @'V2' 'GLboolean'@ from 'GLboolean' components.
 bvec2 :: Expr GLboolean -> Expr GLboolean -> Expr (V2 GLboolean)
-bvec2 x y = FunctionCall "bvec2" [Some x, Some y]
+bvec2 (Expr x) (Expr y) = unsafeLift (FunctionCall "bvec2" [x, y])
 
 -- | Construct a @'V3' 'GLboolean'@ from 'GLboolean' components.
 bvec3 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V3 GLboolean)
-bvec3 x y z = FunctionCall "bvec3" [Some x, Some y, Some z]
+bvec3 (Expr x) (Expr y) (Expr z) = unsafeLift (FunctionCall "bvec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLboolean'@ from 'GLboolean' components.
 bvec4 :: Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr GLboolean -> Expr (V4 GLboolean)
-bvec4 x y z w = FunctionCall "bvec4" [Some x, Some y, Some z, Some w]
+bvec4 (Expr x) (Expr y) (Expr z) (Expr w) = unsafeLift (FunctionCall "bvec4" [x, y, z, w])
 
 -- | Construct a @'V2' 'GLint'@ from 'GLint' components.
 ivec2 :: Expr GLint -> Expr GLint -> Expr (V2 GLint)
-ivec2 x y = FunctionCall "ivec2" [Some x, Some y]
+ivec2 (Expr x) (Expr y) = unsafeLift (FunctionCall "ivec2" [x, y])
 
 -- | Construct a @'V3' 'GLint'@ from 'GLint' components.
 ivec3 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr (V3 GLint)
-ivec3 x y z = FunctionCall "ivec3" [Some x, Some y, Some z]
+ivec3 (Expr x) (Expr y) (Expr z) = unsafeLift (FunctionCall "ivec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLint'@ from 'GLint' components.
 ivec4 :: Expr GLint -> Expr GLint -> Expr GLint -> Expr GLint -> Expr (V4 GLint)
-ivec4 x y z w = FunctionCall "ivec4" [Some x, Some y, Some z, Some w]
+ivec4 (Expr x) (Expr y) (Expr z) (Expr w) = unsafeLift (FunctionCall "ivec4" [x, y, z, w])
 
 -- | Construct a @'V2' 'GLfloat'@ from 'GLfloat' components.
 vec2 :: Expr GLfloat -> Expr GLfloat -> Expr (V2 GLfloat)
-vec2 x y = FunctionCall "vec2" [Some x, Some y]
+vec2 (Expr x) (Expr y) = unsafeLift (FunctionCall "vec2" [x, y])
 
 -- | Construct a @'V3' 'GLfloat'@ from 'GLfloat' components.
 vec3 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V3 GLfloat)
-vec3 x y z = FunctionCall "vec3" [Some x, Some y, Some z]
+vec3 (Expr x) (Expr y) (Expr z) = unsafeLift (FunctionCall "vec3" [x, y, z])
 
 -- | Construct a @'V4' 'GLfloat'@ from 'GLfloat' components.
 vec4 :: Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr GLfloat -> Expr (V4 GLfloat)
-vec4 x y z w = FunctionCall "vec4" [Some x, Some y, Some z, Some w]
+vec4 (Expr x) (Expr y) (Expr z) (Expr w) = unsafeLift (FunctionCall "vec4" [x, y, z, w])


### PR DESCRIPTION
I think it's going to make the intermediate computation step /much/ easier if we're always talking about the same type.

We return to `Cofree TypeSpecifier ExprF` as our `Expr` representation. When we implement observable sharing, this means we get the DeRef structure, `CofreeF TypeSpecifier ExprF` for free. It also means that we can use recursion schemes to generate the AST in potentially more exciting ways (can we use a `histo` to avoid redundant intermediate values?)