### PR TITLE
Implement `MuRef` for `Expr`

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -17,6 +17,8 @@ library
   exposed-modules:
     Shader.Expression
   other-modules:
+    Control.Comonad.Cofree.Extra
+
     Shader.Expression.Addition
     Shader.Expression.Cast
     Shader.Expression.Constants
@@ -26,6 +28,8 @@ library
     Shader.Expression.Vector
   build-depends:
     , base
+    , data-fix
+    , data-reify
     , free
     , language-glsl
     , linear
@@ -45,6 +49,8 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
+    , data-fix
+    , data-reify
     , free
     , hedgehog
     , hspec
@@ -61,6 +67,9 @@ test-suite shaders-test
   build-tool-depends:
     hspec-discover:hspec-discover
   other-modules:
+    Control.Comonad.Cofree.Extra
+    Control.Comonad.Cofree.ExtraSpec
+
     Shader.Expression
     Shader.Expression.SpecHook
     Shader.Expression.Addition

--- a/shaders/source/Control/Comonad/Cofree/Extra.hs
+++ b/shaders/source/Control/Comonad/Cofree/Extra.hs
@@ -1,0 +1,14 @@
+-- |
+-- A couple useful helpers for converting in and out of 'Cofree'.
+module Control.Comonad.Cofree.Extra where
+
+import Control.Comonad.Cofree (Cofree ((:<)))
+import Data.Fix (Fix (Fix))
+
+-- | Annotate every node of a 'Fix' with a value, thus forming a 'Cofree'.
+decorate :: (Functor f) => (f (Fix f) -> x) -> Fix f -> Cofree f x
+decorate f (Fix x) = f x :< fmap (decorate f) x
+
+-- | Remove the annotation "head" at each subtree within the 'Cofree'.
+decapitate :: (Functor f) => Cofree f x -> Fix f
+decapitate (_ :< xs) = Fix (fmap decapitate xs)

--- a/shaders/tests/Control/Comonad/Cofree/ExtraSpec.hs
+++ b/shaders/tests/Control/Comonad/Cofree/ExtraSpec.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Control.Comonad.Cofree.ExtraSpec where
+
+import Control.Comonad.Cofree.Extra (decapitate, decorate)
+import Data.Fix (Fix (Fix))
+import Hedgehog (Gen, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Hspec (Spec, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+genFix :: Gen (Fix [])
+genFix = fmap Fix do
+  Gen.list (Range.linear 0 10) do
+    Gen.small genFix
+
+spec :: Spec
+spec = do
+  it "decorate / decapitate" $ hedgehog do
+    forAll genFix >>= \x ->
+      decapitate (decorate length x) === x


### PR DESCRIPTION
This turned out far neater than I imagined.

Implementing `MuRef` means that we can now use Andy Gill's type-safe observable sharing mechanisms to detect common expressions within our `Expr` trees. These can in turn be used as intermediate bindings in the shader output.  It's very cool that `recursion-schemes` and `data-reify` fit together so neatly.