### PR TITLE
Observe shared subexpressions within an `Expr`

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -24,10 +24,12 @@ library
     Shader.Expression.Constants
     Shader.Expression.Core
     Shader.Expression.Logic
+    Shader.Expression.Share
     Shader.Expression.Type
     Shader.Expression.Vector
   build-depends:
     , base
+    , containers
     , data-fix
     , data-reify
     , free
@@ -36,6 +38,7 @@ library
     , OpenGL
     , recursion-schemes
     , some
+    , transformers-compat
   ghc-options: -Wall -Wextra
   hs-source-dirs: source
   default-language: GHC2021
@@ -49,6 +52,7 @@ test-suite shaders-test
   build-depends:
     , base
     , bytestring
+    , containers
     , data-fix
     , data-reify
     , free
@@ -64,6 +68,7 @@ test-suite shaders-test
     , shaders
     , some
     , string-interpolate
+    , transformers-compat
   build-tool-depends:
     hspec-discover:hspec-discover
   other-modules:
@@ -82,6 +87,8 @@ test-suite shaders-test
     Shader.Expression.CoreSpec
     Shader.Expression.Logic
     Shader.Expression.LogicSpec
+    Shader.Expression.Share
+    Shader.Expression.ShareSpec
     Shader.Expression.Type
     Shader.Expression.Vector
     Shader.Expression.VectorSpec

--- a/shaders/source/Shader/Expression.hs
+++ b/shaders/source/Shader/Expression.hs
@@ -36,6 +36,9 @@ module Shader.Expression
     (&&),
     (||),
     ifThenElse,
+
+    -- * Optimisation
+    share,
   )
 where
 
@@ -44,4 +47,5 @@ import Shader.Expression.Cast (Cast, cast)
 import Shader.Expression.Constants (fromInteger, fromRational, lift)
 import Shader.Expression.Core (Expr, toGLSL)
 import Shader.Expression.Logic (false, ifThenElse, true, (&&), (||))
+import Shader.Expression.Share (share)
 import Shader.Expression.Vector (bvec2, bvec3, bvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4)

--- a/shaders/source/Shader/Expression/Core.hs
+++ b/shaders/source/Shader/Expression/Core.hs
@@ -17,9 +17,12 @@ where
 import Control.Comonad.Cofree (Cofree ((:<)))
 import Control.Comonad.Cofree.Extra (decapitate)
 import Control.Comonad.Trans.Cofree (CofreeF)
+import Data.Functor.Classes (Eq1 (liftEq), Show1 (liftShowsPrec))
+import Data.Functor.Classes.Generic (liftEqDefault, liftShowsPrecDefault)
 import Data.Functor.Foldable (cata, project)
 import Data.Kind (Type)
 import Data.Reify (MuRef (DeRef, mapDeRef))
+import GHC.Generics (Generic1)
 import GHC.Records (HasField (getField))
 import Language.GLSL.Syntax qualified as Syntax
 import Linear (R1, R2, R3, R4)
@@ -30,6 +33,7 @@ import Shader.Expression.Type (Typed (typeOf))
 -- out as intermediate bindings.
 type Expr :: Type -> Type
 newtype Expr x = Expr {unExpr :: Cofree ExprF Syntax.TypeSpecifier}
+  deriving newtype (Eq, Show)
 
 -- | The inner data type for 'Expr'. These constructors should map in very
 -- straightforward ways to 'Syntax.Expr'. We express this as a separate functor
@@ -47,8 +51,14 @@ data ExprF expr
   | And expr expr
   | Or expr expr
   | Selection expr expr expr
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Generic1, Ord, Show)
   deriving stock (Foldable, Functor, Traversable)
+
+instance Eq1 ExprF where
+  liftEq = liftEqDefault
+
+instance Show1 ExprF where
+  liftShowsPrec = liftShowsPrecDefault
 
 instance MuRef (Cofree ExprF x) where
   type DeRef (Cofree ExprF x) = CofreeF ExprF x

--- a/shaders/source/Shader/Expression/Share.hs
+++ b/shaders/source/Shader/Expression/Share.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE BlockArguments #-}
+
+-- |
+-- A utility for observing potential intermediate results in a GLSL shader.
+module Shader.Expression.Share where
+
+import Control.Comonad.Trans.Cofree (CofreeF (..))
+import Data.Foldable (toList)
+import Data.Graph (Vertex, graphFromEdges', reverseTopSort)
+import Data.Reify (Unique, reifyGraph)
+import Data.Reify qualified as Reify
+import Language.GLSL.Syntax qualified as Syntax
+import Shader.Expression.Core (Expr (Expr), ExprF (..))
+
+-- | Consider the following shader:
+--
+--     let v = vec2 1 2 in v.x + v.y
+--
+-- In our basic DSL, @let@ bindings are shallow. What this means is that the
+-- above shader is actually identical to
+--
+--     (vec2 1 2).x + (vec2 1 2).y
+--
+-- We can see how more complex shaders will end up with a /lot/ of duplication,
+-- especially if they involve accessing multiple parts of an intermediate value
+-- like our @v@ here.
+--
+-- What we'd like to do is try to detect these points at which a value (@v@ in
+-- our case) is being referenced in more than one node of our AST. We can then
+-- abstract these points out to intermediate variables, and hopefully improve
+-- our performance.
+--
+-- The downside is that we can no longer talk about our expression language as
+-- being one-to-one with expressions in GLSL: we now have to distinguish
+-- between the final assignments' expressions and the variables that must be
+-- bound before that.
+--
+-- Worse still, these variable assignments have a significant order: you can't
+-- reference a variable before it has been bound. This means we need to keep
+-- track of the /ordered/ list of assignments required, plus the final
+-- expression and its relationship to those bindings.
+--
+-- To do this, we use Andy Gill's type-safe observable sharing ('Data.Reify')
+-- to generate a dependency graph. We then perform a reverse topological sort
+-- on that graph to get our ordered list of assignments. Finally, the "root" of
+-- the graph (as described by 'reifyGraph') gives us the variable to use for
+-- the final assignment.
+--
+-- There's a bunch of stuff I'd love to make cleverer here. For one, there's
+-- plenty we could do with common subexpression elimination. We could also be a
+-- bit cleverer about /what/ we bind as an intermediate: is it worth having an
+-- assignment like @int v0 = 1@ rather than just using @1@ directly? In any
+-- case, these are problems to solve when they become problems.
+share :: Expr x -> IO (Vertex, [(Unique, Syntax.TypeSpecifier, ExprF Unique)])
+share (Expr cofree) = do
+  Reify.Graph mappings entry <- reifyGraph cofree
+
+  let -- Generate a directed, acyclic graph to represent the value dependencies
+      -- within our program. @containers@ is a gift of a library.
+      (graph, nodeFromVertex) =
+        graphFromEdges'
+          [ (node, key, toList node)
+            | (key, node) <- mappings
+          ]
+
+      -- A reverse topological sort should organise the assignments such that an
+      -- assignment only occurs /after/ its dependents have been assigned.
+      matches :: [(Unique, Syntax.TypeSpecifier, ExprF Unique)]
+      matches = do
+        (typeSpecifier :< expression, variable, _) <-
+          map nodeFromVertex (reverseTopSort graph)
+
+        pure (variable, typeSpecifier, expression)
+
+  pure (entry, matches)

--- a/shaders/tests/Shader/Expression/ShareSpec.hs
+++ b/shaders/tests/Shader/Expression/ShareSpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module Shader.Expression.ShareSpec where
+
+import Control.Comonad.Cofree (Cofree ((:<)))
+import Control.Monad.IO.Class (liftIO)
+import Data.Foldable (find)
+import Data.Graph (Vertex)
+import Data.Reify (Unique)
+import Graphics.Rendering.OpenGL (GLfloat)
+import Hedgehog (Gen, MonadTest, annotateShow, failure, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helper.Renderer (Renderer)
+import Language.GLSL.Syntax (TypeSpecifier)
+import Shader.Expression (lift, share, vec2, vec3, vec4)
+import Shader.Expression.Core (Expr (Expr, unExpr), ExprF)
+import Test.Hspec (SpecWith, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+genShader :: Gen (Expr GLfloat)
+genShader = do
+  let genFloat :: Gen (Expr GLfloat)
+      genFloat = fmap lift do
+        Gen.float (Range.linearFrac 0 10)
+
+      genVec2 :: Gen (Expr GLfloat)
+      genVec2 = do
+        x <- genFloat
+        y <- genFloat
+
+        Gen.element
+          [ (vec2 x y).x,
+            (vec2 x y).y
+          ]
+
+      genVec3 :: Gen (Expr GLfloat)
+      genVec3 = do
+        x <- genFloat
+        y <- genFloat
+        z <- genFloat
+
+        Gen.element
+          [ (vec3 x y z).x,
+            (vec3 x y z).y,
+            (vec3 x y z).z
+          ]
+
+      genVec4 :: Gen (Expr GLfloat)
+      genVec4 = do
+        x <- genFloat
+        y <- genFloat
+        z <- genFloat
+        w <- genFloat
+
+        Gen.element
+          [ (vec4 x y z w).x,
+            (vec4 x y z w).y,
+            (vec4 x y z w).z,
+            (vec4 x y z w).w
+          ]
+
+  Gen.recursive Gen.choice [genFloat] [genVec2, genVec3, genVec4]
+
+spec :: SpecWith Renderer
+spec = do
+  it "roundtrips" \_ -> hedgehog do
+    input <- forAll genShader
+
+    shared <- liftIO (share input)
+    annotateShow shared
+
+    let search :: (MonadTest m) => Vertex -> [(Unique, x, y)] -> m (x, y)
+        search index =
+          maybe failure (pure . removeIndex)
+            . find \(check, _, _) -> index == check
+          where
+            removeIndex :: (x, y, z) -> (y, z)
+            removeIndex (_, y, z) = (y, z)
+
+        rebuild :: (MonadTest m) => Vertex -> [(Unique, TypeSpecifier, ExprF Unique)] -> m (Expr GLfloat)
+        rebuild root graph = do
+          (ty, exprF) <- search root graph
+
+          recursed <- traverse (fmap unExpr . flip rebuild graph) exprF
+          pure $ Expr (ty :< recursed)
+
+    output <- uncurry rebuild shared
+    output === input


### PR DESCRIPTION
We'd like to assign common subexpressions to intermediate variables when we build a shader. This avoids redundant computation (see the comment in `Shader.Expression.Share`). It's a pretty nifty little trick.