### PR TITLE
Separate the `shaders-test` target from `shaders` entirely

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,10 @@
-name: test
+name: build
 
 on:
   push
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +27,6 @@ jobs:
 
     - run: |
         cabal update
-        cabal build shaders-test --only-dependencies --enable-tests
+        cabal build all --only-dependencies
 
-    - run: |
-        cabal build shaders-test --enable-tests
-
-    - uses: GabrielBB/xvfb-action@v1
-      with:
-        run: |
-          cabal run shaders-test --enable-tests -- --randomize
+    - run: cabal build all

--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -65,7 +65,6 @@ test-suite shaders-test
     , prettyclass
     , recursion-schemes
     , sdl2
-    , shaders
     , some
     , string-interpolate
     , transformers-compat


### PR DESCRIPTION
`shaders-test` already imports all the modules of `shaders` to make ghcid work. originally, I added its dependency on `shaders` to make sure that I wouldn't, for example, forget to add a module to both.

However, it's a bit of a nuisance: when there's an error in the code included as part of `shaders`, I can't start a ghcid session to fix it for `shaders-test` until I fix the dependency.

This PR removes that dependency, but also adds a CI job to make sure that `shaders` (and future packages!) continue to build.