### PR TITLE
Only run CI jobs relevant to the change

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,7 +1,11 @@
 name: bench
 
 on:
-  push
+  push:
+    - cabal.project
+    - */benchmarks
+    - */source
+    - */*.cabal
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,11 @@
 name: build
 
 on:
-  push
+  push:
+    paths:
+    - cabal.projcet
+    - */source
+    - */*.cabal
 
 jobs:
   build:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,7 +1,9 @@
 name: format
 
 on:
-  push
+  push:
+    paths:
+    - '**.hs'
 
 jobs:
   ormolu:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,9 @@
 name: lint
 
 on:
-  push
+  push:
+    paths:
+    - '**.hs'
 
 jobs:
   hlint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,12 @@ name: test
 
 on:
   push
+    paths:
+    - cabal.projcet
+    - */source
+    - */tests
+    - */*.cabal
+
 
 jobs:
   test:


### PR DESCRIPTION
If I understand GitHub Actions correctly, this should ensure that we only run the checks relevant to the change we're making. This should greatly improve speeds for non-Haskell changes in particular.