### PR TITLE
Re-enable all status checks before merging

### DIFF
--- a/.github/workflows/bench-skip.yaml
+++ b/.github/workflows/bench-skip.yaml
@@ -1,0 +1,15 @@
+name: bench
+
+on:
+  push:
+    paths-ignore:
+    - 'cabal.project'
+    - '*/benchmarks/**'
+    - '*/source/**'
+    - '*/*.cabal'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes detected"'

--- a/.github/workflows/build-skip.yaml
+++ b/.github/workflows/build-skip.yaml
@@ -1,0 +1,14 @@
+name: build
+
+on:
+  push:
+    paths-ignore:
+    - 'cabal.project'
+    - '*/source/**'
+    - '*/*.cabal'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes detected"'

--- a/.github/workflows/format-skip.yaml
+++ b/.github/workflows/format-skip.yaml
@@ -1,0 +1,12 @@
+name: format
+
+on:
+  push:
+    paths-ignore:
+    - '**.hs'
+
+jobs:
+  ormolu:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes detected"'

--- a/.github/workflows/lint-skip.yaml
+++ b/.github/workflows/lint-skip.yaml
@@ -1,0 +1,12 @@
+name: lint
+
+on:
+  push:
+    paths-ignore:
+    - '**.hs'
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes detected"'

--- a/.github/workflows/test-skip.yaml
+++ b/.github/workflows/test-skip.yaml
@@ -1,0 +1,15 @@
+name: test
+
+on:
+  push:
+    paths-ignore:
+    - 'cabal.project'
+    - '*/source/**'
+    - '*/tests/**'
+    - '*/*.cabal'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes detected"'


### PR DESCRIPTION
Apparently, the trick to getting this to work with path filtering is to make a `const true` job that only runs when the real job won't. Let's give it a go.