### PR TITLE
Add the `barbies-extra` package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,15 +33,18 @@ jobs:
 
     - run: |
         cabal update
-        cabal build shaders-test --only-dependencies --enable-tests
+        cabal build barbies-extra-test --only-dependencies --enable-tests
         cabal build free-extra-test --only-dependencies --enable-tests
+        cabal build shaders-test --only-dependencies --enable-tests
 
     - run: |
-        cabal build shaders-test --enable-tests
+        cabal build barbies-extra-test --enable-tests
         cabal build free-extra-test --enable-tests
+        cabal build shaders-test --enable-tests
 
     - uses: GabrielBB/xvfb-action@v1
       with:
         run: |
-          cabal run shaders-test --enable-tests -- --randomize
+          cabal run barbies-extra-test --enable-tests -- --randomize
           cabal run free-extra-test --enable-tests -- --randomize
+          cabal run shaders-test --enable-tests -- --randomize

--- a/barbies-extra/barbies-extra.cabal
+++ b/barbies-extra/barbies-extra.cabal
@@ -1,0 +1,31 @@
+cabal-version: 3.4
+name: barbies-extra
+version: 0.1.0.0
+
+library
+  exposed-modules:
+    Barbies.Extra
+  build-depends:
+    , barbies
+    , base
+  ghc-options: -Wall -Wextra
+  hs-source-dirs: source
+  default-language: GHC2021
+
+test-suite barbies-extra-test
+  default-language: GHC2021
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall -Wextra
+  hs-source-dirs: source, tests
+  main-is: Spec.hs
+  build-depends:
+    , barbies
+    , base
+    , hedgehog
+    , hspec
+    , hspec-hedgehog
+  build-tool-depends:
+    hspec-discover:hspec-discover
+  other-modules:
+    Barbies.Extra
+    Barbies.ExtraSpec

--- a/barbies-extra/source/Barbies/Extra.hs
+++ b/barbies-extra/source/Barbies/Extra.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- |
+-- Extra utilities for @barbies@.
+module Barbies.Extra where
+
+import Barbies (AllB, ApplicativeB (bpure), ConstraintsB, FunctorB (bmap), TraversableB, bfoldMap, bmapC, btraverse, bzipWith)
+import Data.Functor.Const (Const (Const, getConst))
+import Data.Kind (Type)
+
+-- | Let's imagine a very specific use case: I want to use
+-- @Data.Reify.reifyGraphs@ to take @MyStructure Expr@ and produce some shared
+-- bindings among the different properties. @reifyGraphs@ assumes that the
+-- structure is 'Traversable', but we want to use barbie types so that we can
+-- have a set of heterogeneous typed expressions.
+--
+-- 'Aligned' means we can briefly "untype" our 'Expr', perform observable
+-- sharing using the 'Traversable' instance below, and then "retype" our 'Expr'
+-- while collecting helpful intermediate bindings.
+type Aligned :: ((Type -> Type) -> Type) -> (Type -> Type) -> Type -> Type
+data Aligned b f x = Aligned {unAligned :: b (Const (f x))}
+
+instance (FunctorB b, Functor f) => Functor (Aligned b f) where
+  fmap f = Aligned . bmap (Const . fmap f . getConst) . unAligned
+
+instance (ApplicativeB b, Applicative f) => Applicative (Aligned b f) where
+  Aligned fs <*> Aligned xs = Aligned (bzipWith go fs xs)
+    where
+      go (Const f) (Const x) = Const (f <*> x)
+  pure x = Aligned (bpure (Const (pure x)))
+
+instance (TraversableB b, Foldable f) => Foldable (Aligned b f) where
+  foldMap f = bfoldMap (foldMap f . getConst) . unAligned
+
+instance (TraversableB b, Traversable f) => Traversable (Aligned b f) where
+  traverse f = fmap Aligned . btraverse (fmap Const . traverse f . getConst) . unAligned
+
+-- | Convert a regular barbie to an aligned barbie using an unconstrained
+-- function.
+align :: (FunctorB b) => (forall a. f a -> g x) -> b f -> Aligned b g x
+align f = Aligned . bmap (Const . f)
+
+-- | Convert a regular barbie to an aligned barbie using a constrained
+-- function.
+alignC :: forall c b f g x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => f a -> g x) -> b f -> Aligned b g x
+alignC f = Aligned . bmapC @c (Const . f)
+
+-- | Convert an aligned barbie back to a regular barbie using an unconstrained
+-- function.
+unalign :: (FunctorB b) => (forall a. f x -> g a) -> Aligned b f x -> b g
+unalign f = bmap (f . getConst) . unAligned
+
+-- | Convert an aligned barbie back to a regular barbie using a constrained
+-- function.
+unalignC :: forall c b f g x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => f x -> g a) -> Aligned b f x -> b g
+unalignC f = bmapC @c (f . getConst) . unAligned

--- a/barbies-extra/tests/Barbies/ExtraSpec.hs
+++ b/barbies-extra/tests/Barbies/ExtraSpec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Extra utilities for @barbies@.
+module Barbies.ExtraSpec where
+
+import Barbies (AllBF, ApplicativeB (bpure), ConstraintsB, FunctorB, TraversableB)
+import Barbies qualified as B
+import Barbies.Extra (align, alignC, unalign, unalignC)
+import Data.Functor.Identity (Identity)
+import Data.Kind (Type)
+import GHC.Generics (Generic)
+import Hedgehog (Gen, PropertyT, diff, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Hspec (Spec, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+type CoordB :: (Type -> Type) -> Type
+data CoordB f = CoordB
+  { x :: f Float,
+    y :: f Float,
+    z :: f Float
+  }
+  deriving stock (Generic)
+  deriving anyclass (ApplicativeB, ConstraintsB, FunctorB, TraversableB)
+
+deriving instance (AllBF Eq f CoordB) => Eq (CoordB f)
+
+deriving instance (AllBF Show f CoordB) => Show (CoordB f)
+
+genCoordB :: (Applicative f) => Gen (CoordB f)
+genCoordB = do
+  x <- Gen.float (Range.linearFrac 0 1)
+  y <- Gen.float (Range.linearFrac 0 1)
+  z <- Gen.float (Range.linearFrac 0 1)
+
+  pure
+    CoordB
+      { x = pure x,
+        y = pure y,
+        z = pure z
+      }
+
+-- TODO: replace with @isRoughly@ (@isRoughlyB@?)
+(=~=) :: CoordB Identity -> CoordB Identity -> PropertyT IO ()
+(=~=) as bs = x as =~ x bs *> y as =~ y bs *> z as =~ z bs
+  where
+    a =~ b = diff (abs (a - b)) (<) (recip 256)
+
+spec :: Spec
+spec = do
+  it "aligns and unaligns happily" $ hedgehog do
+    xyz <- forAll genCoordB
+
+    let clean :: CoordB Maybe -> CoordB Maybe
+        clean = unalign (const Nothing) . align \_ -> Just ()
+
+    clean xyz === bpure Nothing
+
+  it "alignCs and unalignCs happily" $ hedgehog do
+    xyz <- forAll genCoordB
+
+    let translate :: (Float -> Float) -> CoordB Identity -> CoordB Identity
+        translate f = unalignC @((~) Float) id . fmap f . alignC @((~) Float) id
+
+    translate pred (translate succ xyz) =~= xyz

--- a/barbies-extra/tests/Spec.hs
+++ b/barbies-extra/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
There's a bunch of stuff coming up with shader compilation where we'll want to use barbies, but graph reification requires traversable types. This library allows barbies to have `Traversable` instances by specialising them into a `Const` shape.