### PR TITLE
Bump the Cabal version

### DIFF
--- a/barbies-extra/barbies-extra.cabal
+++ b/barbies-extra/barbies-extra.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.4
+cabal-version: 3.6
 name: barbies-extra
 version: 0.1.0.0
 

--- a/free-extra/free-extra.cabal
+++ b/free-extra/free-extra.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.4
+cabal-version: 3.6
 name: free-extra
 version: 0.1.0.0
 

--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.4
+cabal-version: 3.6
 name: shaders
 version: 0.1.0.0
 


### PR DESCRIPTION
Apparently, we're out of date. GHC 9.4 requires Cabal 3.6.