### PR TITLE
Fix missed HLint warnings

### DIFF
--- a/barbies-extra/source/Barbies/Extra.hs
+++ b/barbies-extra/source/Barbies/Extra.hs
@@ -18,7 +18,7 @@ import Data.Kind (Type)
 -- sharing using the 'Traversable' instance below, and then "retype" our 'Expr'
 -- while collecting helpful intermediate bindings.
 type Aligned :: ((Type -> Type) -> Type) -> (Type -> Type) -> Type -> Type
-data Aligned b f x = Aligned {unAligned :: b (Const (f x))}
+newtype Aligned b f x = Aligned {unAligned :: b (Const (f x))}
 
 instance (FunctorB b, Functor f) => Functor (Aligned b f) where
   fmap f = Aligned . bmap (Const . fmap f . getConst) . unAligned

--- a/free-extra/tests/Control/Comonad/Cofree/ExtraSpec.hs
+++ b/free-extra/tests/Control/Comonad/Cofree/ExtraSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Control.Comonad.Cofree.ExtraSpec (spec) where
 


### PR DESCRIPTION
The problem with a new CI setup that only runs the necessary jobs is that it can't spot problems with existing code. Caught these two small lint issues while running the linter over another PR.