### PR TITLE
Simplify `Aligned`

### DIFF
--- a/barbies-extra/source/Barbies/Extra.hs
+++ b/barbies-extra/source/Barbies/Extra.hs
@@ -6,7 +6,7 @@
 -- Extra utilities for @barbies@.
 module Barbies.Extra where
 
-import Barbies (AllB, ApplicativeB (bpure), ConstraintsB, FunctorB (bmap), TraversableB, bfoldMap, bmapC, btraverse, bzipWith)
+import Barbies (AllB, ApplicativeB, ConstraintsB, FunctorB, TraversableB)
 import Barbies qualified as B
 import Data.Functor.Const (Const (Const, getConst))
 import Data.Kind (Type)
@@ -27,40 +27,40 @@ newtype One x f = One {runOne :: f x}
 -- 'Aligned' means we can briefly "untype" our 'Expr', perform observable
 -- sharing using the 'Traversable' instance below, and then "retype" our 'Expr'
 -- while collecting helpful intermediate bindings.
-type Aligned :: ((Type -> Type) -> Type) -> (Type -> Type) -> Type -> Type
-newtype Aligned b f x = Aligned {unAligned :: b (Const (f x))}
+type Aligned :: ((Type -> Type) -> Type) -> Type -> Type
+newtype Aligned b x = Aligned {unAligned :: b (Const x)}
 
-instance (FunctorB b, Functor f) => Functor (Aligned b f) where
-  fmap f = Aligned . bmap (Const . fmap f . getConst) . unAligned
+instance (FunctorB b) => Functor (Aligned b) where
+  fmap f = Aligned . B.bmap (Const . f . getConst) . unAligned
 
-instance (ApplicativeB b, Applicative f) => Applicative (Aligned b f) where
-  Aligned fs <*> Aligned xs = Aligned (bzipWith go fs xs)
+instance (ApplicativeB b) => Applicative (Aligned b) where
+  Aligned fs <*> Aligned xs = Aligned (B.bzipWith go fs xs)
     where
-      go (Const f) (Const x) = Const (f <*> x)
-  pure x = Aligned (bpure (Const (pure x)))
+      go (Const f) (Const x) = Const (f x)
+  pure x = Aligned (B.bpure (Const x))
 
-instance (TraversableB b, Foldable f) => Foldable (Aligned b f) where
-  foldMap f = bfoldMap (foldMap f . getConst) . unAligned
+instance (TraversableB b) => Foldable (Aligned b) where
+  foldMap f = B.bfoldMap (f . getConst) . unAligned
 
-instance (TraversableB b, Traversable f) => Traversable (Aligned b f) where
-  traverse f = fmap Aligned . btraverse (fmap Const . traverse f . getConst) . unAligned
+instance (TraversableB b) => Traversable (Aligned b) where
+  traverse f = fmap Aligned . B.btraverse (fmap Const . f . getConst) . unAligned
 
 -- | Convert a regular barbie to an aligned barbie using an unconstrained
 -- function.
-align :: (FunctorB b) => (forall a. f a -> g x) -> b f -> Aligned b g x
-align f = Aligned . bmap (Const . f)
+align :: (FunctorB b) => (forall a. f a -> x) -> b f -> Aligned b x
+align f = Aligned . B.bmap (Const . f)
 
 -- | Convert a regular barbie to an aligned barbie using a constrained
 -- function.
-alignC :: forall c b f g x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => f a -> g x) -> b f -> Aligned b g x
-alignC f = Aligned . bmapC @c (Const . f)
+alignC :: forall c b f x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => f a -> x) -> b f -> Aligned b x
+alignC f = Aligned . B.bmapC @c (Const . f)
 
 -- | Convert an aligned barbie back to a regular barbie using an unconstrained
 -- function.
-unalign :: (FunctorB b) => (forall a. f x -> g a) -> Aligned b f x -> b g
-unalign f = bmap (f . getConst) . unAligned
+unalign :: (FunctorB b) => (forall a. x -> g a) -> Aligned b x -> b g
+unalign f = B.bmap (f . getConst) . unAligned
 
 -- | Convert an aligned barbie back to a regular barbie using a constrained
 -- function.
-unalignC :: forall c b f g x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => f x -> g a) -> Aligned b f x -> b g
-unalignC f = bmapC @c (f . getConst) . unAligned
+unalignC :: forall c b g x. (AllB c b, ConstraintsB b, FunctorB b) => (forall a. (c a) => x -> g a) -> Aligned b x -> b g
+unalignC f = B.bmapC @c (f . getConst) . unAligned

--- a/barbies-extra/tests/Barbies/ExtraSpec.hs
+++ b/barbies-extra/tests/Barbies/ExtraSpec.hs
@@ -11,7 +11,7 @@ module Barbies.ExtraSpec where
 import Barbies (AllBF, ApplicativeB (bpure), ConstraintsB, FunctorB, TraversableB)
 import Barbies qualified as B
 import Barbies.Extra (align, alignC, unalign, unalignC)
-import Data.Functor.Identity (Identity)
+import Data.Functor.Identity (Identity (Identity, runIdentity))
 import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Hedgehog (Gen, PropertyT, diff, forAll, (===))
@@ -66,6 +66,6 @@ spec = do
     xyz <- forAll genCoordB
 
     let translate :: (Float -> Float) -> CoordB Identity -> CoordB Identity
-        translate f = unalignC @((~) Float) id . fmap f . alignC @((~) Float) id
+        translate f = unalignC @((~) Float) Identity . fmap f . alignC @((~) Float) runIdentity
 
     translate pred (translate succ xyz) =~= xyz


### PR DESCRIPTION
We don't need an `f` parameter because (for all our purposes) it'll be `Identity` anyway.