### PR TITLE
Simplify `Roughly` a la `approx`

### DIFF
--- a/roughly/roughly.cabal
+++ b/roughly/roughly.cabal
@@ -9,6 +9,7 @@ library
     , base
     , hedgehog
     , hspec
+    , linear
   hs-source-dirs: source
   default-language: GHC2021
 

--- a/roughly/source/Helper/Roughly.hs
+++ b/roughly/source/Helper/Roughly.hs
@@ -1,32 +1,61 @@
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DerivingVia #-}
 
 module Helper.Roughly where
 
 import Control.Monad.Zip (MonadZip (mzipWith))
 import Data.Function (on)
-import Data.Kind (Type)
+import Data.Functor.Identity (Identity (Identity))
+import Data.Kind (Constraint, Type)
 import Hedgehog (MonadTest, (===))
+import Linear (V1, V2, V3, V4)
 import Test.Hspec (Expectation, shouldBe)
 
 -- | A "rough equality" check on two vectors. We're doing a lot of floating
 -- point arithmetic, so we're going to end up with some sort of error.
-isRoughly :: (MonadTest m, MonadZip f, Foldable f, Fractional x, Ord x, Show (f x)) => f x -> f x -> m ()
+isRoughly :: (MonadTest m, Approximate x, Show x) => x -> x -> m ()
 isRoughly = (===) `on` Roughly
 
 -- | Like 'isRoughly', but specifically for Hspec expectations.
-shouldRoughlyBe :: (MonadZip f, Foldable f, Fractional x, Ord x, Show (f x)) => f x -> f x -> Expectation
+shouldRoughlyBe :: (Approximate x, Show x) => x -> x -> Expectation
 shouldRoughlyBe = shouldBe `on` Roughly
 
 -- | A type that implements "rough" equality, where "rough" precisely means
 -- that two values are equal if no absolute component-wise difference is more
 -- than a 256th of the total.
-type Roughly :: (Type -> Type) -> Type -> Type
-newtype Roughly f x = Roughly (f x)
-  deriving stock (Foldable, Traversable)
-  deriving newtype (Show, Functor, Applicative)
+type Roughly :: Type -> Type
+newtype Roughly x = Roughly {precisely :: x}
+  deriving stock (Foldable, Show, Traversable)
+  deriving (Functor, Applicative) via Identity
 
-instance (MonadZip f, Foldable f, Fractional x, Ord x) => Eq (Roughly f x) where
-  Roughly xs == Roughly ys = and (mzipWith isCloseEnough xs ys)
-    where
-      isCloseEnough :: x -> x -> Bool
-      isCloseEnough x y = abs (x - y) <= maximum [1, abs x, abs y] / 256
+instance (Approximate x) => Eq (Roughly x) where
+  Roughly x == Roughly y = x =~ y
+
+-- | A class for rough equality. The laws are pretty loose here, but we'd at
+-- least expect the following to hold:
+--
+-- prop> x =~ y === y =~ x
+-- prop> x == y ==> x =~ y
+-- prop> not (x == y) ==> x /= y
+type Approximate :: Type -> Constraint
+class Approximate x where
+  -- | Are these two values roughly equal?
+  (=~) :: x -> x -> Bool
+
+instance Approximate Float where
+  x =~ y = abs (x - y) <= maximum [1, abs x, abs y] / 256
+
+instance Approximate Double where
+  x =~ y = abs (x - y) <= maximum [1, abs x, abs y] / 256
+
+instance (Approximate x) => Approximate (V1 x) where
+  xs =~ ys = and (mzipWith (=~) xs ys)
+
+instance (Approximate x) => Approximate (V2 x) where
+  xs =~ ys = and (mzipWith (=~) xs ys)
+
+instance (Approximate x) => Approximate (V3 x) where
+  xs =~ ys = and (mzipWith (=~) xs ys)
+
+instance (Approximate x) => Approximate (V4 x) where
+  xs =~ ys = and (mzipWith (=~) xs ys)

--- a/roughly/tests/Helper/RoughlySpec.hs
+++ b/roughly/tests/Helper/RoughlySpec.hs
@@ -10,34 +10,86 @@ import Linear (V3)
 import Test.Hspec (Spec, it)
 import Test.Hspec.Hedgehog (hedgehog)
 
-genVector :: Gen (V3 Float)
-genVector = sequence $ pure do
-  Gen.float (Range.linearFrac 0 1000)
-
 spec :: Spec
 spec = do
+  it "commutative double addition" $ hedgehog do
+    x <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.double (Range.linearFrac 0 1000)
+
+    (x + y) `isRoughly` (y + x)
+
+  it "associative double addition" $ hedgehog do
+    x <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    z <- forAll $ Gen.double (Range.linearFrac 0 1000)
+
+    (x + (y + z)) `isRoughly` ((x + y) + z)
+
+  it "commutative double multiplication" $ hedgehog do
+    x <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.double (Range.linearFrac 0 1000)
+
+    (x * y) `isRoughly` (y * x)
+
+  it "associative double multiplication" $ hedgehog do
+    x <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.double (Range.linearFrac 0 1000)
+    z <- forAll $ Gen.double (Range.linearFrac 0 1000)
+
+    (x * (y * z)) `isRoughly` ((x * y) * z)
+
   it "commutative float addition" $ hedgehog do
-    x <- forAll genVector
-    y <- forAll genVector
+    x <- forAll $ Gen.float (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.float (Range.linearFrac 0 1000)
 
     (x + y) `isRoughly` (y + x)
 
   it "associative float addition" $ hedgehog do
-    x <- forAll genVector
-    y <- forAll genVector
-    z <- forAll genVector
+    x <- forAll $ Gen.float (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.float (Range.linearFrac 0 1000)
+    z <- forAll $ Gen.float (Range.linearFrac 0 1000)
 
     (x + (y + z)) `isRoughly` ((x + y) + z)
 
   it "commutative float multiplication" $ hedgehog do
-    x <- forAll genVector
-    y <- forAll genVector
+    x <- forAll $ Gen.float (Range.linearFrac 0 1000)
+    y <- forAll $ Gen.float (Range.linearFrac 0 1000)
 
     (x * y) `isRoughly` (y * x)
 
+  let vector :: Gen (V3 Float)
+      vector = sequence $ pure do
+        Gen.float (Range.linearFrac 0 1000)
+
   it "associative float multiplication" $ hedgehog do
-    x <- forAll genVector
-    y <- forAll genVector
-    z <- forAll genVector
+    x <- forAll vector
+    y <- forAll vector
+    z <- forAll vector
+
+    (x * (y * z)) `isRoughly` ((x * y) * z)
+
+  it "commutative vector addition" $ hedgehog do
+    x <- forAll vector
+    y <- forAll vector
+
+    (x + y) `isRoughly` (y + x)
+
+  it "associative vector addition" $ hedgehog do
+    x <- forAll vector
+    y <- forAll vector
+    z <- forAll vector
+
+    (x + (y + z)) `isRoughly` ((x + y) + z)
+
+  it "commutative vector multiplication" $ hedgehog do
+    x <- forAll vector
+    y <- forAll vector
+
+    (x * y) `isRoughly` (y * x)
+
+  it "associative vector multiplication" $ hedgehog do
+    x <- forAll vector
+    y <- forAll vector
+    z <- forAll vector
 
     (x * (y * z)) `isRoughly` ((x * y) * z)


### PR DESCRIPTION
I wanted to use the `approx` library, but the `Float` equality check isn't lenient enough for our purposes. The alternatives all involved a whole bunch of newtypes and type-level stuff, which seemed heavier than just implementing a stripped down version of `approx` myself.