### PR TITLE
Enable benchmarks on all builds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages: */*.cabal
 
 library-for-ghci: true
+benchmarks: true
 tests: true
 
 package *


### PR DESCRIPTION
Forgot to add this when I updated `cabal.project` to enable tests. Should fix #67.