### PR TITLE
Create an HLint configuration file, fix missed suggestion

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+- ignore:
+    name: Use <$>

--- a/roughly/source/Helper/Roughly.hs
+++ b/roughly/source/Helper/Roughly.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DerivingVia #-}
 
 module Helper.Roughly where


### PR DESCRIPTION
I don't really like the operators, and I'd like to see less of them. While fixing HLint to stop telling me about them, I found a different lint error that I hadn't fixed, and fixed it.