### PR TITLE
Implement the generic toolbox

### DIFF
--- a/.github/workflows/generic-toolbox.yaml
+++ b/.github/workflows/generic-toolbox.yaml
@@ -1,0 +1,26 @@
+name: generic-toolbox
+
+on:
+  push
+
+jobs:
+  generic-toolbox-build:
+    uses: ./.github/workflows/helper-build.yaml
+    with:
+      package: "generic-toolbox"
+
+  generic-toolbox-format:
+    uses: ./.github/workflows/helper-format.yaml
+    with:
+      package: "generic-toolbox"
+
+  generic-toolbox-lint:
+    uses: ./.github/workflows/helper-lint.yaml
+    with:
+      package: "generic-toolbox"
+
+  generic-toolbox-test:
+    uses: ./.github/workflows/helper-test.yaml
+    with:
+      package: "generic-toolbox"
+

--- a/generic-toolbox/generic-toolbox.cabal
+++ b/generic-toolbox/generic-toolbox.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.6
+name: generic-toolbox
+version: 0.1.0.0
+
+library
+  exposed-modules:
+    Toolbox.Generic
+  build-depends:
+    , base
+  hs-source-dirs: source
+  default-language: GHC2021
+
+test-suite generic-toolbox-test
+  default-language: GHC2021
+  type: exitcode-stdio-1.0
+  hs-source-dirs: source, tests
+  main-is: Spec.hs
+  build-depends:
+    , base
+    , hspec
+  build-tool-depends:
+    hspec-discover:hspec-discover
+  other-modules:
+    Toolbox.Generic
+    Toolbox.GenericSpec

--- a/generic-toolbox/source/Toolbox/Generic.hs
+++ b/generic-toolbox/source/Toolbox/Generic.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Helpful generic utilities.
+module Toolbox.Generic where
+
+import Control.Applicative (liftA2)
+import Data.Functor.Const (Const (Const, getConst))
+import Data.Functor.Identity (Identity (Identity, runIdentity))
+import Data.Kind (Constraint, Type)
+import Data.Proxy (Proxy (Proxy))
+import GHC.Generics
+import GHC.TypeLits (KnownSymbol, symbolVal)
+
+-- | Any standard ADT can be "traversed" with a function we apply to every
+-- field on the current constructor, supplying the field name along with it.
+type Traverse :: (Type -> Constraint) -> Type -> Constraint
+class Traverse c s where
+  -- | Apply a function to every field of every constructor, giving them their
+  -- own field names. Note that this assumes constructors are all records.
+  itraverse :: (Applicative f) => (forall a. (c a) => String -> a -> f a) -> s -> f s
+
+-- | The generic machinery behind 'Traverse'.
+type GTraverse :: (Type -> Constraint) -> (Type -> Type) -> Constraint
+class GTraverse c rep where
+  -- | An implementation of 'itraverse' over generic representations.
+  gitraverse :: (Applicative f) => (forall a. (c a) => String -> a -> f a) -> rep x -> f (rep x)
+
+instance (GTraverse c x) => GTraverse c (D1 meta x) where
+  gitraverse f = fmap M1 . gitraverse @c f . unM1
+
+instance (GTraverse c x) => GTraverse c (C1 meta x) where
+  gitraverse f = fmap M1 . gitraverse @c f . unM1
+
+instance (GTraverse c l, GTraverse c r) => GTraverse c (l :*: r) where
+  gitraverse f (l :*: r) = liftA2 (:*:) (gitraverse @c f l) (gitraverse @c f r)
+
+instance (GTraverse c l, GTraverse c r) => GTraverse c (l :+: r) where
+  gitraverse f = \case
+    L1 l -> fmap L1 (gitraverse @c f l)
+    R1 r -> fmap R1 (gitraverse @c f r)
+
+instance
+  (KnownSymbol name, c x, meta ~ 'MetaSel ('Just name) i d k) =>
+  GTraverse c (S1 meta (K1 r x))
+  where
+  gitraverse f = fmap (M1 . K1) . f key . unK1 . unM1
+    where
+      key = symbolVal (Proxy @name)
+
+instance (Generic x, GTraverse c (Rep x)) => Traverse c x where
+  itraverse f = fmap to . gitraverse @c f . from
+
+-- | A version of 'itraverse' that ignores the record field name.
+traverse :: forall c f s. (Applicative f, Traverse c s) => (forall a. (c a) => a -> f a) -> s -> f s
+traverse f = itraverse @c (const f)
+
+-- | Fold over a record type with access to the field names.
+ifoldMap :: forall c s m. (Traverse c s, Monoid m) => (forall a. (c a) => String -> a -> m) -> s -> m
+ifoldMap f = getConst . itraverse @c (\s -> Const . f s)
+
+-- | Fold over a record type.
+foldMap :: forall c s m. (Traverse c s, Monoid m) => (forall a. (c a) => a -> m) -> s -> m
+foldMap f = ifoldMap @c (const f)
+
+-- | A version of 'itraverse' that doesn't produce an 'Applicative' effect.
+imap :: forall c s. (Traverse c s) => (forall a. (c a) => String -> a -> a) -> s -> s
+imap f = runIdentity . itraverse @c (\s -> Identity . f s)
+
+-- | A version of 'imap' that ignores the record field name.
+map :: forall c s. (Traverse c s) => (forall a. (c a) => a -> a) -> s -> s
+map f = imap @c (const f)

--- a/generic-toolbox/tests/Spec.hs
+++ b/generic-toolbox/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/generic-toolbox/tests/Toolbox/GenericSpec.hs
+++ b/generic-toolbox/tests/Toolbox/GenericSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Toolbox.GenericSpec where
+
+import Data.Kind (Type)
+import GHC.Generics (Generic)
+import Test.Hspec (Spec, it, shouldBe)
+import Toolbox.Generic qualified as Generic
+
+type User :: Type
+data User = User {name :: String, age :: Int, likesDogs :: Bool}
+  deriving stock (Eq, Generic, Show)
+
+type Coord :: Type
+data Coord = Coord {x :: Float, y :: Float, z :: Float}
+  deriving stock (Eq, Generic, Show)
+
+spec :: Spec
+spec = do
+  let user :: User
+      user = User {name = "Tom", age = 30, likesDogs = True}
+
+  it "itraverse" do
+    let f :: String -> x -> ([String], x)
+        f k v = (pure k, v)
+
+    Generic.itraverse @Show f user
+      `shouldBe` (["name", "age", "likesDogs"], user)
+
+  it "traverse" do
+    let f :: (Show x) => x -> ([String], x)
+        f v = (pure (show v), v)
+
+    Generic.traverse @Show f user
+      `shouldBe` (["\"Tom\"", "30", "True"], user)
+
+  it "ifoldMap" do
+    let f :: (Show x) => String -> x -> [String]
+        f "age" v = pure (show v)
+        f _____ _ = mempty
+
+    Generic.ifoldMap @Show f user `shouldBe` ["30"]
+
+  it "foldMap" do
+    let f :: (Show x) => x -> [String]
+        f = pure . show
+
+    Generic.foldMap @Show f user
+      `shouldBe` ["\"Tom\"", "30", "True"]
+
+  let coord :: Coord
+      coord = Coord {x = 1, y = 2, z = 3}
+
+  it "imap" do
+    let f :: String -> Float -> Float
+        f s x =
+          x + fromIntegral do
+            sum (map fromEnum s)
+
+    Generic.imap @((~) Float) f coord
+      `shouldBe` Coord 121 123 125
+
+  it "map" do
+    Generic.map @((~) Float) (+ 1) coord
+      `shouldBe` Coord 2 3 4


### PR DESCRIPTION
Functions that are probably going to end up being useful in the compilation phase. Ideally, these would be better placed in a library like `one-liner`, but it doesn't have any field name accessors as far as I can tell.