### PR TITLE
Make assignments classier

### DIFF
--- a/shaders/shaders.cabal
+++ b/shaders/shaders.cabal
@@ -31,6 +31,7 @@ library
     , data-reify
     , free
     , free-extra
+    , generic-toolbox
     , language-glsl
     , linear
     , OpenGL
@@ -54,6 +55,7 @@ test-suite shaders-test
     , data-reify
     , free
     , free-extra
+    , generic-toolbox
     , hedgehog
     , hspec
     , hspec-hedgehog


### PR DESCRIPTION
Now we have the `generic-toolbox`, we can factor out all the ugly generics stuff, and this gets a lot easier to comprehend. The tests also get a lot clearer.